### PR TITLE
[easy] Add Check When Mounting debugfs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-psutil
-pyyaml
 Jinja2
+psutil
 pytest
+pyyaml

--- a/setup.sh
+++ b/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
-apt-get update >/dev/null
-apt-get -y install linux-headers-$(uname -r)
-mount -t debugfs debugfs /sys/kernel/debug
+DEBUG_PATH=/sys/kernel/debug
+
+apt-get update
+apt-get -y install linux-headers-"$(uname -r)"
+if  ! mountpoint -q $DEBUG_PATH; then
+    mount -t debugfs debugfs $DEBUG_PATH
+fi


### PR DESCRIPTION
Simple fix to allow running of `./run.sh` multiple times because `./setup.sh` failed when debugfs was already mounted.

Tested that running `./run.sh`, CTRL-C'ing out, then running `./run.sh` within the docker container still gives JSON output.
