### PR TITLE
Use ring buffer instead of debug interface to publish events

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.md
+include LICENSE

--- a/main.py
+++ b/main.py
@@ -10,6 +10,7 @@ import yaml
 
 from bcc import BPF
 from datetime import datetime
+from functools import partial
 from jinja2 import Template
 from pidtree_bcc import utils
 
@@ -26,6 +27,12 @@ bpf_text = """
 {% endfor %}
 
 BPF_HASH(currsock, u32, struct sock *);
+struct connection_t {
+    u32 pid;
+    u32 daddr;
+    u16 dport;
+}
+BPF_PERF_OUTPUT(events);
 
 int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
 {
@@ -72,9 +79,13 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
 
     bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
 
-    bpf_trace_printk("{\\"pid\\": %d, \\"daddr\\": \\"%x\\", \\"dport\\": %d}\\n",
-                     pid, daddr, ntohs(dport));
-    
+    struct connection_t connection = {};
+    connection.pid = pid;
+    connection.port = ntohs(dport);
+    connection.daddr = daddr;
+
+    events.perf_submit(ctx, &connection, sizeof(connection))
+
     currsock.delete(&pid);
 
     return 0;
@@ -102,7 +113,30 @@ def parse_config(config_file):
 def ip_to_int(network):
     """ Takes an IP and returns the unsigned integer encoding of the address """
     return struct.unpack('=L', socket.inet_aton(network))[0]
-    
+
+
+def enrich_event(b, event):
+    proctree_enriched = []
+    error = ""
+    try:
+        proc = psutil.Process(event.pid)
+        proctree = utils.crawl_process_tree(proc)
+        proctree_enriched = list({"pid": p.pid, "cmdline": " ".join(p.cmdline()), "username":  p.username()} for p in proctree)
+    except Exception as e:
+        error=str(e)
+    return(
+        {"timestamp": datetime.utcnow().isoformat() + 'Z',
+        "pid": event.pid,
+        "proctree": proctree_enriched,
+        "daddr": socket.inet_ntoa(struct.pack('<L', int(event.daddr, 16))),
+        "port": event.dport,
+        "error": error})
+
+def print_enriched_event(b, cpu, data, size):
+    event = b["events"].event(data)
+    print >> out, json.dumps(enrich_event(b, event))
+    out.flush()
+
 def main(args):
     config = parse_config(args.config)
     global bpf_text
@@ -115,29 +149,10 @@ def main(args):
         print(expanded_bpf_text)
         sys.exit(0)
     b = BPF(text=expanded_bpf_text)
+    b["events"].open_perf_buffer(partial(print_enriched_event, b))
     with utils.smart_open(args.output_file, mode='w') as out:
         while True:
-            trace = b.trace_readline()
-            # print(trace)
-            proctree_enriched = []
-            error = ""
-            try:
-                # FIXME: this next line isn't right - sometimes there are more colons
-                json_event = trace.split(":", 2)[2:][0]
-                event = json.loads(json_event)
-                proc = psutil.Process(event["pid"])
-                proctree = utils.crawl_process_tree(proc)
-                proctree_enriched = list({"pid": p.pid, "cmdline": " ".join(p.cmdline()), "username":  p.username()} for p in proctree)
-            except Exception as e:
-                error=str(e)
-            print >> out, json.dumps(
-                {"timestamp": datetime.utcnow().isoformat() + 'Z',
-                 "pid": event["pid"],
-                 "proctree": proctree_enriched,
-                 "daddr": socket.inet_ntoa(struct.pack('<L', int(event["daddr"], 16))),
-                 "port": event["dport"],
-                 "error": error})
-            out.flush()
+            b.perf_buffer_poll()
     sys.exit(0)
 
 if __name__ == "__main__":

--- a/pidtree_bcc/utils.py
+++ b/pidtree_bcc/utils.py
@@ -1,5 +1,4 @@
 import psutil
-import contextlib
 import sys
 
 def crawl_process_tree(proc):
@@ -12,15 +11,9 @@ def crawl_process_tree(proc):
         procs.append(psutil.Process(ppid))
     return procs
 
-@contextlib.contextmanager
 def smart_open(filename=None, mode='r'):
-    """ Contextmanager for file OR stdout open, shamelessly cribbed from https://stackoverflow.com/questions/17602878/how-to-handle-both-with-open-and-sys-stdout-nicely """
+    """ File OR stdout open """
     if filename and filename != '-':
-        fh = open(filename, mode)
+        return(open(filename, mode))
     else:
-        fh = sys.stdout
-    try:
-        yield fh
-    finally:
-        if fh is not sys.stdout:
-            fh.close()
+        return(sys.stdout)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 import setuptools
-import os
 
 with open("README.md", "r") as fh:
     long_description = fh.read()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,9 +25,6 @@ def test_crawl_process_tree(this_proc, this_pid):
     assert tree[-1].pid == 1 # should be init
 
 def test_smart_open(this_file):
-    with utils.smart_open() as out:
-        assert out == sys.stdout
-    with utils.smart_open('-') as out:
-        assert out == sys.stdout
-    with utils.smart_open(this_file) as out:
-        assert out.name == this_file
+    assert utils.smart_open() == sys.stdout
+    assert utils.smart_open('-') == sys.stdout
+    assert utils.smart_open(this_file).name == this_file


### PR DESCRIPTION
So basically, when I wrote the original PoC for this project, I used [bpf_trace_printk()](https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#1-bpf_trace_printk) to get the messages to userland. Note that in the documentation it says not to do that for production code. The upshot of this is it makes `pidtree-bcc` not be multi-tenant as only one thing can use it per-kernel (without, say, message routing).

This review changes it to use the recommended [BPF_PERF_OUTPUT(event)](https://github.com/iovisor/bcc/blob/master/docs/reference_guide.md#2-bpf_perf_output) which required some restructuring of the code due to the use of callbacks. This gives us a few advantages:
1. We're not relying on other neighbours on the same kernel not using `bpf_trace_printk`
2. We're now multi-tenant (you can run multiple instances with multiple filters woo!)
3. As a result of 2 you can now write and run itests on a machine that's also running `pidtree-bcc` to stop 1337 haxx0rs, and also run them in parallel for multiple builds
4. There's no hand-hacked json or string parsing - the data being passed around are raw structs of number based types.
5. As far as I can tell it should actually *improve* performance because it does fewer type conversions, passes less data in aggregate because json has been moved out of scope, and it must have been using a ring-buffer for `bpf_trace_printk` anyway because I can't think of any other way it would have been copying the data from kernel to userspace.
6. Deletes the code that did some rather suspect parsing of  the`bpf_trace_printk` line format

I've left new unit tests and itests out of scope for this particular PR because a) there's no regression of coverage introduced (i.e. we didn't have them in the first place), b) I'd rather get these changes out now so that other people can contribute to the tests and c) I ran it multi-tenant on a machine and it worked just fine!