### PR TITLE
Better itest failure

### DIFF
--- a/itest/itest.sh
+++ b/itest/itest.sh
@@ -56,6 +56,7 @@ function wait_for_tame_output {
       echo "DEBUG: \$line is $line"
     fi
   done < "$FIFO_NAME"
+	return 1
 }
 
 function main {

--- a/itest/itest.sh
+++ b/itest/itest.sh
@@ -56,7 +56,7 @@ function wait_for_tame_output {
       echo "DEBUG: \$line is $line"
     fi
   done < "$FIFO_NAME"
-	return 1
+  return 1
 }
 
 function main {

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 DEBUG_PATH=/sys/kernel/debug
 INSTALL_ONLY=${INSTALL_ONLY:-false}
@@ -6,7 +6,7 @@ INSTALL_ONLY=${INSTALL_ONLY:-false}
 apt-get update
 apt-get -y install linux-headers-"$(uname -r)"
 
-$INSTALL_ONLY && exit 0
+if [ "$INSTALL_ONLY" = "true" ]; then exit 0; fi
 
 if  ! mountpoint -q $DEBUG_PATH; then
     mount -t debugfs debugfs $DEBUG_PATH


### PR DESCRIPTION
I was having the itests report success due to pidtree's failure to actually run on an unsupported system (kernel header package not present, pidtree never actually launches) due to lack of explicit fails.