### PR TITLE
Add bypass_ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,23 +121,23 @@ or 172.16/12 ranges because of the subnet filters I've included in the
 list of addresses you might want to filter, so you can use the example
 configuration to write your own.
 
-Additionally, you can include config like:
+Additionally, you can make the filters apply only to certain ports, using except_ports and include_ports.
+For example:
 
 ```yaml
-includeports:
-  - 22
-  - 443
-  - 80
+filters:
+  - subnet_name: 10
+    network: 10.0.0.0
+    network_mask : 255.0.0.0
+    description: "all RFC 1918 10/8"
+    except_ports: [80]
 ```
 
-To see *only* events for these ports. The results will still be filtered by the subnet filters. If you'd like
-the traffic from a specific port that bypasses the subnet filters, use:
+Would mean filter out all traffic from 10.0.0.0/8 except for that on port 80. If you changed except_ports
+to include_ports, then it would filter out only traffic to 10.0.0.0/8 on port 80.
 
-```yaml
-bypass_ports:
- - 80
- - 123
- ```
+In addition, you can add a global config for filtering out all traffic except those for specific ports,
+using the option `includeports`.
 
 ## Plugins
 Plugin configuration is populated using the `plugins` key at the top level of the configuration:

--- a/README.md
+++ b/README.md
@@ -130,7 +130,14 @@ includeports:
   - 80
 ```
 
-To see *only* events for these ports.
+To see *only* events for these ports. The results will still be filtered by the subnet filters. If you'd like
+the traffic from a specific port that bypasses the subnet filters, use:
+
+```yaml
+bypass_ports:
+ - 80
+ - 123
+ ```
 
 ## Plugins
 Plugin configuration is populated using the `plugins` key at the top level of the configuration:

--- a/example_config.yml
+++ b/example_config.yml
@@ -4,12 +4,14 @@ filters:
     network: 10.0.0.0
     network_mask : 255.0.0.0
     description: "all RFC 1918 10/8"
-    except_ports: [80, 120]
   - subnet_name: 17216
     network: 172.16.0.0
     network_mask : 255.240.0.0
     description: "all RFC 1918 172.16/12"
-    include_ports: [123, 456]
+  - subnet_name: 169254
+    network: 169.254.0.0
+    network_mask : 255.255.0.0
+    description: "all 169.254/16 loopback"
   - subnet_name: 127
     network: 127.0.0.0
     network_mask : 255.0.0.0

--- a/example_config.yml
+++ b/example_config.yml
@@ -4,14 +4,12 @@ filters:
     network: 10.0.0.0
     network_mask : 255.0.0.0
     description: "all RFC 1918 10/8"
+    except_ports: [80, 120]
   - subnet_name: 17216
     network: 172.16.0.0
     network_mask : 255.240.0.0
     description: "all RFC 1918 172.16/12"
-  - subnet_name: 169254
-    network: 169.254.0.0
-    network_mask : 255.255.0.0
-    description: "all 169.254/16 loopback"
+    include_ports: [123, 456]
   - subnet_name: 127
     network: 127.0.0.0
     network_mask : 255.0.0.0

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-i mport argparse
+import argparse
 import json
 import os
 import psutil

--- a/main.py
+++ b/main.py
@@ -1,4 +1,4 @@
-import argparse
+i mport argparse
 import json
 import os
 import psutil
@@ -63,25 +63,45 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
     u32 saddr = 0, daddr = 0;
     u16 dport = 0;
     bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+    //
+    // For each filter, drop the packet iff
+    // - a filter's subnet matches AND 
+    // - the port is not one of the filter's excepted ports AND
+    // - the port is one of the filter's included ports, if they exist
+    //
     if (0 // for easier templating 
-    {% for filter in filters %}
-         || (subnet_{{ filter["subnet_name"] }} & subnet_{{ filter["subnet_name"] }}_mask) == (daddr & subnet_{{ filter["subnet_name"] }}_mask)
-    {% endfor %}{% for port in bypass_ports %}
-         || ntohs({{ port }}) == dport
-    {% endfor %}) {
+    {% for filter in filters -%}
+         || ( (subnet_{{ filter["subnet_name"] }} & subnet_{{ filter["subnet_name"] }}_mask) == (daddr & subnet_{{ filter["subnet_name"] }}_mask)
+              && ( 1 == 1  // For easier templating
+                {% for port in filter.get('except_ports', []) -%}
+                && ntohs({{ port }}) != dport
+                {% endfor -%}
+              )
+              && ( 
+                {% if filter.get('include_ports') -%}
+                    0
+                    {% for port in filter.get('include_ports', []) -%}
+                      || ntohs({{ port }}) == dport
+                    {% endfor -%} 
+                {% else -%}
+                1
+                {% endif -%}
+              )
+           )
+    {% endfor %} ) {
         currsock.delete(&pid);
         return 0;
     }
     bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
-    {% if includeports != []: %}
+    {% if includeports != []: -%}
     if ( 1 
-    {% for port in includeports + bypass_ports %}
+    {% for port in includeports -%}
         && ntohs({{ port }}) != dport 
     {% endfor %}) {
         currsock.delete(&pid);
         return 0;
     }
-    {% endif %}
+    {% endif -%}
 
     bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
 
@@ -173,7 +193,6 @@ def main(args):
         ip_to_int=ip_to_int,
         filters=config.get("filters", []),
         includeports=config.get("includeports", []),
-        bypass_ports=config.get('bypass_ports', [])
     )
     if args.print_and_quit:
         print(expanded_bpf_text)


### PR DESCRIPTION
This adds a new config options `include_ports` and `exclude_ports` for the filters to make them apply to certain ports only.

Example output:
```
$ cat example_config.yaml
---
filters:
  - subnet_name: 10
    network: 10.0.0.0
    network_mask : 255.0.0.0
    description: "all RFC 1918 10/8"
    except_ports: [80]
  - subnet_name: 17216
    network: 172.16.0.0
    network_mask : 255.240.0.0
    description: "all RFC 1918 172.16/12"
    include_ports: [80, 123]
```
leads to
```
    //
    // For each filter, drop the packet iff
    // - a filter's subnet matches AND
    // - the port is not one of the filter's excepted ports AND
    // - the port is one of the filter's included ports, if they exist
    //
    if (0 // for easier templating
    || ( (subnet_10 & subnet_10_mask) == (daddr & subnet_10_mask)
              && ( 1 == 1  // For easier templating
                && ntohs(80) != dport
                )
              && (
                1
                )
           )
    || ( (subnet_17216 & subnet_17216_mask) == (daddr & subnet_17216_mask)
              && ( 1 == 1  // For easier templating
                )
              && (
                0
                    || ntohs(80) == dport
                    || ntohs(123) == dport
                    )
           )
     ) {
        currsock.delete(&pid);
        return 0;
    }
```
which I've compiled and run.