### PR TITLE
Version v0.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="pidtree-bcc",
-    version="0.3",
+    version="0.5",
     author="Matt Carroll",
     author_email="mattc@yelp.com",
     description="eBPF-based intrusion detection and audit logging",
@@ -15,7 +15,7 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     license='BSD 3-clause "New" or "Revised License"',
     classifiers=[
-        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 3",
         "License :: OSI Approved :: BSD License",
         "Operating System :: Linux",
     ],


### PR DESCRIPTION
Update the version number. This includes changes from https://github.com/Yelp/pidtree-bcc/pull/26. Please note that v0.4 exists in git tags but didn't have setup.py updated. After I merge this to master I'll tag that as v0.5.