### PR TITLE
Fix except/include_ports

### DIFF
--- a/main.py
+++ b/main.py
@@ -63,6 +63,7 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
     u32 saddr = 0, daddr = 0;
     u16 dport = 0;
     bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
     //
     // For each filter, drop the packet iff
     // - a filter's subnet matches AND 
@@ -92,7 +93,6 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
         currsock.delete(&pid);
         return 0;
     }
-    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
     {% if includeports != []: -%}
     if ( 1 
     {% for port in includeports -%}


### PR DESCRIPTION
daddr is not actually set before the first round of filters, which means that except_ports/include_ports doesn't work. To fix this, I moved the probe call above the filters.

If this incurs a significant performance hit, I could separate the filters so that they are done in two stages, one with no port filters first, and then those with port filters after the probe.

I tested this change with except_ports and it works.