### PR TITLE
fix travis config in order to run unit-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,16 @@
-language: generic
-dist: xenial
+---
+language: python
+python: ['3.5', '3.6', '3.7']
+install: sudo pip install tox-travis
+script: tox
 
-install:
-  - sudo apt-get -y install netcat-traditional
-  - sudo update-alternatives --set nc /bin/nc.traditional
-  - sudo pip install tox-travis
-#env: DEBUG=true
-script: sudo make test-all
+jobs:
+  include:
+    - name: itest
+      language: generic
+      dist: xenial
+      install:
+        - sudo apt-get -y install netcat-traditional
+        - sudo update-alternatives --set nc /bin/nc.traditional
+        - sudo pip install tox-travis
+      script: sudo make test-all


### PR DESCRIPTION
I noticed that Travis was not running unit tests. We cannot have python versions not available via apt, but I think we should be able to define multiple jobs with different "languages".