### PR TITLE
run unit tests via coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,24 @@
+[run]
+branch = True
+source =
+    .
+omit =
+    .tox/*
+    virtualenv_run/*
+    venv/*
+    /usr/*
+    setup.py
+
+[report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    \#\s*pragma: no cover
+
+    # Don't complain if tests don't hit defensive assertion code:
+    ^\s*raise AssertionError\b
+    ^\s*raise NotImplementedError\b
+    ^\s*return NotImplemented\b
+    ^\s*raise$
+
+    # Don't complain if non-runnable code isn't run:
+    ^if __name__ == ['"]__main__['"]:$

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ testhosts
 **/debian-binary
 packaging/dist
 itest/dist
+.coverage

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,4 @@
 -r requirements.txt
+coverage<5.0  # https://github.com/nedbat/coveragepy/issues/703
 pre-commit>1.0.0
 pytest

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,9 @@ envlist = py35,py36,py37
 
 [testenv]
 deps = -rrequirements-dev.txt
-commands = pytest
+commands =
+    coverage run -m pytest --strict -rxs
+    coverage report -m
 
 [testenv:venv]
 basepython = /usr/bin/python3.7


### PR DESCRIPTION
Because I'm in love with code coverage tables
```
py37 runtests: commands[1] | coverage report -m
Name                                    Stmts   Miss Branch BrPart  Cover   Missing
-----------------------------------------------------------------------------------
pidtree_bcc/__init__.py                     1      0      0      0   100%
pidtree_bcc/main.py                        73     73     10      0     0%   1-268
pidtree_bcc/plugin.py                      33      4     12      1    84%   63-72, 56->63
pidtree_bcc/plugins/__init__.py             0      0      0      0   100%
pidtree_bcc/plugins/identityplugin.py       4      1      0      0    75%   8
pidtree_bcc/plugins/loginuidmap.py         26      5      8      2    79%   17, 35, 37-39, 16->17, 34->35
pidtree_bcc/plugins/sourceipmap.py         43      2     20      3    92%   76, 80, 69->71, 75->76, 79->80
pidtree_bcc/probes/__init__.py              2      2      0      0     0%   1-2
pidtree_bcc/utils.py                       16      0      4      0   100%
tests/loginuid_plugin_test.py              16      0      2      0   100%
tests/plugin_test.py                       25      0      0      0   100%
tests/sourceipmap_plugin_test.py           17      0      0      0   100%
tests/utils_test.py                        21      0      0      0   100%
-----------------------------------------------------------------------------------
TOTAL                                     277     87     56      6    68%
```