### PR TITLE
make BPF probes modular

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include README.md
 include LICENSE
+include pidtree_bcc/probes/*.j2

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ MAKEFLAGS += --warn-undefined-variables
 
 .PHONY: dev-env itest test test-all cook-image docker-run docker-run-with-fifo docker-interactive testhosts docker-run-testhosts clean clean-cache install-hooks
 FIFO = $(CURDIR)/pidtree-bcc.fifo
-EXTRA_DOCKER_ARGS? =
+EXTRA_DOCKER_ARGS ?=
 DOCKER_ARGS = $(EXTRA_DOCKER_ARGS) -v /etc/passwd:/etc/passwd:ro --privileged --cap-add sys_admin --pid host
 HOST_OS_RELEASE = $(or $(shell cat /etc/lsb-release 2>/dev/null | grep -Po '(?<=CODENAME=)(.+)'), bionic)
 

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,25 +1,25 @@
 ---
-filters:
-  - subnet_name: 10
-    network: 10.0.0.0
-    network_mask : 255.0.0.0
-    description: "all RFC 1918 10/8"
-  - subnet_name: 17216
-    network: 172.16.0.0
-    network_mask : 255.240.0.0
-    description: "all RFC 1918 172.16/12"
-  - subnet_name: 169254
-    network: 169.254.0.0
-    network_mask : 255.255.0.0
-    description: "all 169.254/16 loopback"
-  - subnet_name: 127
-    network: 127.0.0.0
-    network_mask : 255.0.0.0
-    description: "all 127/8 loopback"
-
-plugins:
-  sourceipmap:
-    enabled: True
-    hostfiles:
-      - '/etc/hosts'
-    attribute_key: "source_host"
+tcp_connect:
+  filters:
+    - subnet_name: 10
+      network: 10.0.0.0
+      network_mask : 255.0.0.0
+      description: "all RFC 1918 10/8"
+    - subnet_name: 17216
+      network: 172.16.0.0
+      network_mask : 255.240.0.0
+      description: "all RFC 1918 172.16/12"
+    - subnet_name: 169254
+      network: 169.254.0.0
+      network_mask : 255.255.0.0
+      description: "all 169.254/16 loopback"
+    - subnet_name: 127
+      network: 127.0.0.0
+      network_mask : 255.0.0.0
+      description: "all 127/8 loopback"
+  plugins:
+    sourceipmap:
+      enabled: True
+      hostfiles:
+        - '/etc/hosts'
+      attribute_key: "source_host"

--- a/itest/example_config.yml
+++ b/itest/example_config.yml
@@ -1,38 +1,39 @@
 ---
-filters:
-  - subnet_name: 0_0_0_0__2
-    network: 0.0.0.0
-    network_mask: 192.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 64_0_0_0__3
-    network: 64.0.0.0
-    network_mask: 224.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 96_0_0_0__4
-    network: 96.0.0.0
-    network_mask: 240.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 112_0_0_0__5
-    network: 112.0.0.0
-    network_mask: 248.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 120_0_0_0__6
-    network: 120.0.0.0
-    network_mask: 252.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 124_0_0_0__7
-    network: 124.0.0.0
-    network_mask: 254.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 126_0_0_0__8
-    network: 126.0.0.0
-    network_mask: 255.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 128_0_0_0__1
-    network: 128.0.0.0
-    network_mask: 128.0.0.0
-    description: "Non-loopback subnet section"
-  - subnet_name: 127_0_0_0__16
-    network: 127.0.0.0
-    network_mask: 255.255.0.0
-    description: "127.0/16 to get rid of the noise"
+tcp_connect:
+  filters:
+    - subnet_name: 0_0_0_0__2
+      network: 0.0.0.0
+      network_mask: 192.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 64_0_0_0__3
+      network: 64.0.0.0
+      network_mask: 224.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 96_0_0_0__4
+      network: 96.0.0.0
+      network_mask: 240.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 112_0_0_0__5
+      network: 112.0.0.0
+      network_mask: 248.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 120_0_0_0__6
+      network: 120.0.0.0
+      network_mask: 252.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 124_0_0_0__7
+      network: 124.0.0.0
+      network_mask: 254.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 126_0_0_0__8
+      network: 126.0.0.0
+      network_mask: 255.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 128_0_0_0__1
+      network: 128.0.0.0
+      network_mask: 128.0.0.0
+      description: "Non-loopback subnet section"
+    - subnet_name: 127_0_0_0__16
+      network: 127.0.0.0
+      network_mask: 255.255.0.0
+      description: "127.0/16 to get rid of the noise"

--- a/itest/mapping_config.yml
+++ b/itest/mapping_config.yml
@@ -1,27 +1,28 @@
 ---
-filters:
-  - subnet_name: 10
-    network: 10.0.0.0
-    network_mask : 255.0.0.0
-    description: "all RFC 1918 10/8"
-  - subnet_name: 17216
-    network: 172.16.0.0
-    network_mask : 255.240.0.0
-    description: "all RFC 1918 172.16/12"
-  - subnet_name: 169254
-    network: 169.254.0.0
-    network_mask : 255.255.0.0
-    description: "all 169.254/16 loopback"
-  - subnet_name: 127
-    network: 127.0.0.0
-    network_mask : 255.0.0.0
-    description: "all 127/8 loopback"
+tcp_connect:
+  filters:
+    - subnet_name: 10
+      network: 10.0.0.0
+      network_mask : 255.0.0.0
+      description: "all RFC 1918 10/8"
+    - subnet_name: 17216
+      network: 172.16.0.0
+      network_mask : 255.240.0.0
+      description: "all RFC 1918 172.16/12"
+    - subnet_name: 169254
+      network: 169.254.0.0
+      network_mask : 255.255.0.0
+      description: "all 169.254/16 loopback"
+    - subnet_name: 127
+      network: 127.0.0.0
+      network_mask : 255.0.0.0
+      description: "all 127/8 loopback"
 
-plugins:
-  sourceipmap:
-    enabled: True
-    attribute_key: "source_container"
-    hostfiles:
-      - /maps/ipmapping.txt
-  identityplugin:
-    enabled: True
+  plugins:
+    sourceipmap:
+      enabled: True
+      attribute_key: "source_container"
+      hostfiles:
+        - /maps/ipmapping.txt
+    identityplugin:
+      enabled: True

--- a/pidtree_bcc/main.py
+++ b/pidtree_bcc/main.py
@@ -1,134 +1,20 @@
 import argparse
-import json
 import os
 import signal
-import socket
-import struct
 import sys
-import traceback
-from datetime import datetime
 from functools import partial
+from multiprocessing import Process
+from multiprocessing import SimpleQueue
 from typing import Any
 from typing import List
 from typing import TextIO
 
-import psutil
 import yaml
-from bcc import BPF
-from jinja2 import Template
 
 from pidtree_bcc import __version__
-from pidtree_bcc import utils
-from pidtree_bcc.plugins import BasePlugin
-from pidtree_bcc.plugins import load_plugins
-
-
-bpf_text = """
-
-#include <net/sock.h>
-#include <bcc/proto.h>
-
-// IPs and masks are given in integer notation with their dotted notation in the comment
-{% for filter in filters %}
-// {{ filter.get("description", filter["subnet_name"]) }}
-#define subnet_{{ filter["subnet_name"] }} {{ ip_to_int(filter["network"]) }} // {{ filter["network"] }}
-#define subnet_{{ filter["subnet_name"] }}_mask {{ ip_to_int(filter["network_mask"]) }} // {{ filter["network_mask"] }}
-{% endfor %}
-
-BPF_HASH(currsock, u32, struct sock *);
-BPF_PERF_OUTPUT(events);
-
-struct connection_t {
-    u32 pid;
-    u32 daddr;
-    u32 saddr;
-    u16 dport;
-};
-
-
-int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
-{
-    u32 pid = bpf_get_current_pid_tgid();
-    currsock.update(&pid, &sk);
-    return 0;
-};
-
-int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
-{
-    int ret = PT_REGS_RC(ctx);
-    u32 pid = bpf_get_current_pid_tgid();
-
-    struct sock **skpp;
-    skpp = currsock.lookup(&pid);
-    if (skpp == 0) return 0; // not there!
-    if (ret != 0) {
-        // failed to sync
-        currsock.delete(&pid);
-        return 0;
-    }
-
-    struct sock *skp = *skpp;
-    u32 saddr = 0, daddr = 0;
-    u16 dport = 0;
-    bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
-    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
-    //
-    // For each filter, drop the packet iff
-    // - a filter's subnet matches AND
-    // - the port is not one of the filter's excepted ports AND
-    // - the port is one of the filter's included ports, if they exist
-    //
-    if (0 // for easier templating
-    {% for filter in filters -%}
-         || ( (
-                subnet_{{ filter["subnet_name"] }}
-                & subnet_{{ filter["subnet_name"] }}_mask
-              ) == (daddr & subnet_{{ filter["subnet_name"] }}_mask)
-              && ( 1 == 1  // For easier templating
-                {% for port in filter.get('except_ports', []) -%}
-                && ntohs({{ port }}) != dport
-                {% endfor -%}
-              )
-              && (
-                {% if filter.get('include_ports') -%}
-                    0
-                    {% for port in filter.get('include_ports', []) -%}
-                      || ntohs({{ port }}) == dport
-                    {% endfor -%}
-                {% else -%}
-                1
-                {% endif -%}
-              )
-           )
-    {% endfor %} ) {
-        currsock.delete(&pid);
-        return 0;
-    }
-    {% if includeports != []: -%}
-    if ( 1
-    {% for port in includeports -%}
-        && ntohs({{ port }}) != dport
-    {% endfor %}) {
-        currsock.delete(&pid);
-        return 0;
-    }
-    {% endif -%}
-
-    bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
-
-    struct connection_t connection = {};
-    connection.pid = pid;
-    connection.dport = ntohs(dport);
-    connection.daddr = daddr;
-    connection.saddr = saddr;
-
-    events.perf_submit(ctx, &connection, sizeof(connection));
-
-    currsock.delete(&pid);
-
-    return 0;
-}
-"""
+from pidtree_bcc.probes import BPFProbe
+from pidtree_bcc.utils import find_subclass
+from pidtree_bcc.utils import smart_open
 
 
 def parse_args() -> argparse.Namespace:
@@ -157,7 +43,7 @@ def parse_args() -> argparse.Namespace:
 
 
 def parse_config(config_file: str) -> dict:
-    """ Parses yaml config file
+    """ Parses yaml config file (if indicated)
 
     :param str config_file: config file path
     :return: configuration dictionary
@@ -168,103 +54,52 @@ def parse_config(config_file: str) -> dict:
         return yaml.safe_load(f)
 
 
-def sigint_handler(signum: int, frame: Any):
-    """ Generic SIGINT handler """
+def sigint_handler(
+    probe_workers: List[Process],
+    output_file: TextIO,
+    signum: int,
+    frame: Any,
+):
+    """ SIGINT handler
+
+    :param List[Process] probe_workers: list of sub-processes to terminate
+    :param TextIO output_file: event output file (to be closed)
+    :param int signum: signal integer code
+    :param Any frame: signal stack frame
+    """
     sys.stderr.write('Caught SIGINT, exiting\n')
+    for worker in probe_workers:
+        worker.terminate()
+    output_file.close()
     sys.exit(0)
 
 
-def ip_to_int(network: str) -> int:
-    """ Takes an IP and returns the unsigned integer encoding of the address
-
-    :param str network: ip address
-    :return: unsigned integer encoding
-    """
-    return struct.unpack('=L', socket.inet_aton(network))[0]
-
-
-def enrich_event(event: Any) -> dict:
-    """ Takes the raw event data and enriches by adding process tree metadata
-
-    :param Any event: BPF event data
-    :return: event dictionary
-    """
-    proctree_enriched = []
-    error = ''
-    try:
-        proc = psutil.Process(event.pid)
-        proctree = utils.crawl_process_tree(proc)
-        proctree_enriched = [
-            {
-                'pid': p.pid,
-                'cmdline': ' '.join(p.cmdline()),
-                'username': p.username(),
-            } for p in proctree
-        ]
-    except Exception:
-        error = traceback.format_exc()
-    return {
-        'timestamp': datetime.utcnow().isoformat() + 'Z',
-        'pid': event.pid,
-        'proctree': proctree_enriched,
-        # We're turning a little-endian insigned long ('<L')
-        # representation of the destination address sent from the
-        # kernel to a python `int` and then turning that into a string
-        # representation of an IP address:
-        'daddr': socket.inet_ntoa(struct.pack('<L', event.daddr)),
-        'saddr': socket.inet_ntoa(struct.pack('<L', event.saddr)),
-        'port': event.dport,
-        'error': error,
-    }
-
-
-def print_enriched_event(
-    b: BPF,
-    out: TextIO,
-    plugins: List[BasePlugin],
-    cpu: Any,
-    data: Any,
-    size: Any,
-):
-    """ A callback for printing enriched event metadata, should be
-    passed as a partial to the callback registering function as
-    `partial(print_enriched_event, b, out)`.
-
-    :param BPF b: BPF object from bcc-toolkit
-    :param file out: output stream
-    :param List[plugin.BasePlugin] plugins: list of loaded plugins
-    :param Any cpu: unused arg required for callback
-    :param Any data: BPF raw event
-    :param Any size: unused arg required for callback
-    """
-    event = b['events'].event(data)
-    event = enrich_event(event)
-    for event_plugin in plugins:
-        event = event_plugin.process(event)
-    print(json.dumps(event), file=out)
-    out.flush()
-
-
 def main(args: argparse.Namespace):
-    signal.signal(signal.SIGINT, sigint_handler)
+    probe_workers = []
+    out = smart_open(args.output_file, mode='w')
+    signal.signal(signal.SIGINT, partial(sigint_handler, probe_workers, out))
     config = parse_config(args.config)
-    plugins = load_plugins(config.get('plugins', {}))
-    global bpf_text
-    expanded_bpf_text = Template(bpf_text).render(
-        ip_to_int=ip_to_int,
-        filters=config.get('filters', []),
-        includeports=config.get('includeports', []),
-    )
+    output_queue = SimpleQueue()
+    probes = {
+        probe_name: find_subclass(
+            'pidtree_bcc.probes.{}'.format(probe_name),
+            BPFProbe,
+        )(output_queue, probe_config)
+        for probe_name, probe_config in config.items()
+        if not probe_name.startswith('_')
+    }
     if args.print_and_quit:
-        print(expanded_bpf_text)
+        for probe_name, probe in probes.items():
+            print('----- {} -----'.format(probe_name))
+            print(probe.expanded_bpf_text)
+            print('\n')
         sys.exit(0)
-    out = utils.smart_open(args.output_file, mode='w')
-    b = BPF(text=expanded_bpf_text)
-    b['events'].open_perf_buffer(
-        partial(print_enriched_event, b, out, plugins),
-    )
+    for probe in probes.values():
+        probe_workers.append(Process(target=probe.start_polling))
+        probe_workers[-1].start()
     while True:
-        b.perf_buffer_poll()
+        print(output_queue.get(), file=out)
+        out.flush()
     out.close()
     sys.exit(0)
 

--- a/pidtree_bcc/plugins/__init__.py
+++ b/pidtree_bcc/plugins/__init__.py
@@ -1,4 +1,4 @@
-import sys
+import logging
 from typing import List
 
 from pidtree_bcc.utils import find_subclass
@@ -71,7 +71,7 @@ def load_plugins(plugin_dict: dict, plugin_dir: str = 'pidtree_bcc.plugins') -> 
         finally:
             if error:
                 if unload_on_init_exception:
-                    sys.stderr.write(str(error) + '\n')
+                    logging.error(str(error))
                 else:
                     raise error
     return plugins

--- a/pidtree_bcc/plugins/loginuidmap.py
+++ b/pidtree_bcc/plugins/loginuidmap.py
@@ -1,5 +1,5 @@
+import logging
 import pwd
-import sys
 from typing import Tuple
 
 from pidtree_bcc.plugins import BasePlugin
@@ -51,5 +51,5 @@ class LoginuidMap(BasePlugin):
                 return None, None
             return loginuid, pwd.getpwuid(loginuid).pw_name
         except Exception as e:
-            sys.stderr.write('Error fetching loginuid: {}'.format(e))
+            logging.error('Error fetching loginuid: {}'.format(e))
         return None, None

--- a/pidtree_bcc/probes/__init__.py
+++ b/pidtree_bcc/probes/__init__.py
@@ -1,0 +1,70 @@
+import inspect
+import json
+import re
+from multiprocessing import SimpleQueue
+from typing import Any
+
+from bcc import BPF
+from jinja2 import Template
+
+from pidtree_bcc.plugins import load_plugins
+
+
+class BPFProbe:
+    """ Base class for defining BPF probes.
+
+    Takes care of loading a BPF program and polling events.
+    The BPF program can be either define in the `BPF_TEXT` class variable or
+    in a Jinja template file (.j2) with the same basename of the module file.
+    In either case the program text will be processed in Jinja templating.
+    """
+
+    def __init__(self, output_queue: SimpleQueue, probe_config: dict = {}):
+        """ Constructor
+
+        :param Queue output_queue: queue for event output
+        :param dict probe_config: (optional) config passed as kwargs to BPF template
+                                  all fields are passed to the template engine with the exception
+                                  of "plugins". This behaviour can be overidden with the TEMPLATE_VARS
+                                  class variable defining a list of config fields.
+        """
+        self.output_queue = output_queue
+        self.plugins = load_plugins(probe_config.get('plugins', {}))
+        if not hasattr(self, 'BPF_TEXT'):
+            module_src = inspect.getsourcefile(type(self))
+            with open(re.sub(r'\.py$', '.j2', module_src)) as f:
+                self.BPF_TEXT = f.read()
+        if hasattr(self, 'TEMPLATE_VARS'):
+            template_config = {k: probe_config[k] for k in self.TEMPLATE_VARS}
+        else:
+            template_config = probe_config.copy()
+            template_config.pop('plugins', None)
+        self.expanded_bpf_text = Template(self.BPF_TEXT).render(**template_config)
+
+    def _process_events(self, cpu: Any, data: Any, size: Any):
+        """ BPF event callback
+
+        :param Any cpu: unused arg required for callback
+        :param Any data: BPF raw event
+        :param Any size: unused arg required for callback
+        """
+        event = self.bpf['events'].event(data)
+        event = self.enrich_event(event)
+        for event_plugin in self.plugins:
+            event = event_plugin.process(event)
+        self.output_queue.put(json.dumps(event))
+
+    def start_polling(self):
+        """ Start infinite loop polling BPF events """
+        self.bpf = BPF(text=self.expanded_bpf_text)
+        self.bpf['events'].open_perf_buffer(self._process_events)
+        while True:
+            self.bpf.perf_buffer_poll()
+
+    def enrich_event(self, event: Any) -> dict:
+        """ Transform raw BPF event data into dictionary,
+        possibly adding more interesting data to it.
+
+        :param Any event: BPF event data
+        """
+        raise NotImplementedError

--- a/pidtree_bcc/probes/tcp_connect.j2
+++ b/pidtree_bcc/probes/tcp_connect.j2
@@ -1,0 +1,102 @@
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+// IPs and masks are given in integer notation with their dotted notation in the comment
+{% for filter in filters %}
+// {{ filter.get("description", filter["subnet_name"]) }}
+#define subnet_{{ filter["subnet_name"] }} {{ ip_to_int(filter["network"]) }} // {{ filter["network"] }}
+#define subnet_{{ filter["subnet_name"] }}_mask {{ ip_to_int(filter["network_mask"]) }} // {{ filter["network_mask"] }}
+{% endfor %}
+
+BPF_HASH(currsock, u32, struct sock *);
+BPF_PERF_OUTPUT(events);
+
+struct connection_t {
+    u32 pid;
+    u32 daddr;
+    u32 saddr;
+    u16 dport;
+};
+
+int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    currsock.update(&pid, &sk);
+    return 0;
+};
+
+int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
+{
+    int ret = PT_REGS_RC(ctx);
+    u32 pid = bpf_get_current_pid_tgid();
+
+    struct sock **skpp;
+    skpp = currsock.lookup(&pid);
+    if (skpp == 0) return 0; // not there!
+    if (ret != 0) {
+        // failed to sync
+        currsock.delete(&pid);
+        return 0;
+    }
+
+    struct sock *skp = *skpp;
+    u32 saddr = 0, daddr = 0;
+    u16 dport = 0;
+    bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
+    bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    //
+    // For each filter, drop the packet iff
+    // - a filter's subnet matches AND
+    // - the port is not one of the filter's excepted ports AND
+    // - the port is one of the filter's included ports, if they exist
+    //
+    if (0 // for easier templating
+    {% for filter in filters -%}
+         || ( (
+                subnet_{{ filter["subnet_name"] }}
+                & subnet_{{ filter["subnet_name"] }}_mask
+              ) == (daddr & subnet_{{ filter["subnet_name"] }}_mask)
+              && ( 1 == 1  // For easier templating
+                {% for port in filter.get('except_ports', []) -%}
+                && ntohs({{ port }}) != dport
+                {% endfor -%}
+              )
+              && (
+                {% if filter.get('include_ports') -%}
+                    0
+                    {% for port in filter.get('include_ports', []) -%}
+                      || ntohs({{ port }}) == dport
+                    {% endfor -%}
+                {% else -%}
+                1
+                {% endif -%}
+              )
+           )
+    {% endfor %} ) {
+        currsock.delete(&pid);
+        return 0;
+    }
+    {% if includeports != []: -%}
+    if ( 1
+    {% for port in includeports -%}
+        && ntohs({{ port }}) != dport
+    {% endfor %}) {
+        currsock.delete(&pid);
+        return 0;
+    }
+    {% endif -%}
+
+    bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
+
+    struct connection_t connection = {};
+    connection.pid = pid;
+    connection.dport = ntohs(dport);
+    connection.daddr = daddr;
+    connection.saddr = saddr;
+
+    events.perf_submit(ctx, &connection, sizeof(connection));
+
+    currsock.delete(&pid);
+
+    return 0;
+}

--- a/pidtree_bcc/probes/tcp_connect.py
+++ b/pidtree_bcc/probes/tcp_connect.py
@@ -1,0 +1,55 @@
+import socket
+import struct
+import traceback
+from datetime import datetime
+from multiprocessing import SimpleQueue
+from typing import Any
+
+import psutil
+
+from pidtree_bcc.probes import BPFProbe
+from pidtree_bcc.utils import crawl_process_tree
+from pidtree_bcc.utils import ip_to_int
+
+
+class TCPConnectProbe(BPFProbe):
+
+    def __init__(self, output_queue: SimpleQueue, probe_config: dict = {}):
+        probe_config['ip_to_int'] = ip_to_int
+        probe_config.setdefault('filters', [])
+        probe_config.setdefault('includeports', [])
+        super().__init__(output_queue, probe_config)
+
+    def enrich_event(self, event: Any) -> dict:
+        """ Parses TCP connect event and adds process tree data
+
+        :param Any event: BPF event
+        :return: event dictionary with process tree
+        """
+        proctree_enriched = []
+        error = ''
+        try:
+            proc = psutil.Process(event.pid)
+            proctree = crawl_process_tree(proc)
+            proctree_enriched = [
+                {
+                    'pid': p.pid,
+                    'cmdline': ' '.join(p.cmdline()),
+                    'username': p.username(),
+                } for p in proctree
+            ]
+        except Exception:
+            error = traceback.format_exc()
+        return {
+            'timestamp': datetime.utcnow().isoformat() + 'Z',
+            'pid': event.pid,
+            'proctree': proctree_enriched,
+            # We're turning a little-endian insigned long ('<L')
+            # representation of the destination address sent from the
+            # kernel to a python `int` and then turning that into a string
+            # representation of an IP address:
+            'daddr': socket.inet_ntoa(struct.pack('<L', event.daddr)),
+            'saddr': socket.inet_ntoa(struct.pack('<L', event.saddr)),
+            'port': event.dport,
+            'error': error,
+        }

--- a/pidtree_bcc/utils.py
+++ b/pidtree_bcc/utils.py
@@ -1,5 +1,7 @@
 import importlib
 import inspect
+import socket
+import struct
 import sys
 from typing import List
 from typing import TextIO
@@ -52,3 +54,12 @@ def find_subclass(module_path: str, base_class: Type) -> Type:
         and issubclass(obj, base_class)
         and obj != base_class
     )
+
+
+def ip_to_int(network: str) -> int:
+    """ Takes an IP and returns the unsigned integer encoding of the address
+
+    :param str network: ip address
+    :return: unsigned integer encoding
+    """
+    return struct.unpack('=L', socket.inet_aton(network))[0]

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setuptools.setup(
     packages=setuptools.find_packages(
         exclude=('tests*', 'itest*', 'packaging*'),
     ),
+    include_package_data=True,
     license='BSD 3-clause "New" or "Revised License"',
     scripts=['bin/pidtree-bcc'],
     classifiers=[

--- a/tests/bpf_probe_test.py
+++ b/tests/bpf_probe_test.py
@@ -1,0 +1,19 @@
+from pidtree_bcc.probes import BPFProbe
+
+
+class MockProbe(BPFProbe):
+    BPF_TEXT = r'''some text
+{{ some_variable }}
+some other text'''
+
+
+def test_pbf_templating():
+    mock_probe = MockProbe(None, {'some_variable': 'some_value'})
+    assert mock_probe.expanded_bpf_text == '''some text
+some_value
+some other text'''
+    MockProbe.TEMPLATE_VARS = ['some_variable']
+    mock_probe = MockProbe(None, {'some_variable': 'some_value', 'rand_config': 1})
+    assert mock_probe.expanded_bpf_text == '''some text
+some_value
+some other text'''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import sys
+from unittest.mock import MagicMock
+
+
+# Globally mock bcc module
+bcc = MagicMock()
+sys.modules.setdefault('bcc', bcc)

--- a/tests/plugin_test.py
+++ b/tests/plugin_test.py
@@ -35,12 +35,11 @@ def test_plugins_exception_on_no_file():
     assert 'No module named ' in str(e)
 
 
-def test_plugins_exception_with_unload(capsys):
+def test_plugins_exception_with_unload(caplog):
     plugins = load_plugins({
         'please_dont_make_a_plugin_called_this': {'unload_on_init_exception': True},
         'identityplugin': {},
     })
-    captured = capsys.readouterr()
     assert len(plugins) == 1
     assert isinstance(plugins[0], Identityplugin)
-    assert 'Could not import pidtree_bcc.plugins.please_dont_make_a_plugin_called_this' in captured.err
+    assert 'Could not import pidtree_bcc.plugins.please_dont_make_a_plugin_called_this' in caplog.text

--- a/tests/tcp_connect_probe_test.py
+++ b/tests/tcp_connect_probe_test.py
@@ -1,0 +1,51 @@
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from pidtree_bcc.probes.tcp_connect import TCPConnectProbe
+from pidtree_bcc.utils import ip_to_int
+
+
+@patch('pidtree_bcc.probes.tcp_connect.datetime')
+@patch('pidtree_bcc.probes.tcp_connect.crawl_process_tree')
+@patch('pidtree_bcc.probes.tcp_connect.psutil')
+def test_tcp_connect_enrich_event(mock_psutil, mock_crawl, mock_datetime):
+    probe = TCPConnectProbe(None)
+    mock_event = MagicMock(
+        pid=123,
+        dport=80,
+        daddr=ip_to_int('1.1.1.1'),
+        saddr=ip_to_int('127.0.0.1'),
+    )
+    mock_crawl.return_value = [
+        MagicMock(
+            pid=123,
+            cmdline=lambda: ['curl', '1.1.1.1'],
+            username=lambda: 'foo',
+        ),
+        MagicMock(
+            pid=50,
+            cmdline=lambda: ['bash'],
+            username=lambda: 'foo',
+        ),
+        MagicMock(
+            pid=1,
+            cmdline=lambda: ['init'],
+            username=lambda: 'root',
+        ),
+    ]
+    mock_datetime.utcnow.return_value.isoformat.return_value = 'x'
+    assert probe.enrich_event(mock_event) == {
+        'timestamp': 'xZ',
+        'pid': 123,
+        'proctree': [
+            {'pid': 123, 'cmdline': 'curl 1.1.1.1', 'username': 'foo'},
+            {'pid': 50, 'cmdline': 'bash', 'username': 'foo'},
+            {'pid': 1, 'cmdline': 'init', 'username': 'root'},
+        ],
+        'daddr': '1.1.1.1',
+        'saddr': '127.0.0.1',
+        'port': 80,
+        'error': '',
+    }
+    mock_psutil.Process.assert_called_once_with(123)
+    mock_crawl.assert_called_once_with(mock_psutil.Process.return_value)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -34,3 +34,8 @@ def test_smart_open(this_file):
     assert utils.smart_open() == sys.stdout
     assert utils.smart_open('-') == sys.stdout
     assert utils.smart_open(this_file).name == this_file
+
+
+def test_ip_to_int():
+    assert utils.ip_to_int('127.0.0.1') == 16777343
+    assert utils.ip_to_int('10.10.10.10') == 168430090

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,8 @@ commands =
 basepython = /usr/bin/python3.7
 envdir = venv
 commands =
+# to allow system-level python3-bcc
+sitepackages = true
 
 [flake8]
 max-line-length = 120


### PR DESCRIPTION
This is going to be a big diff, I'll try my best to summarize the implementation:
* the top level keys in the config now indicate the probes to load (unless they start with `_`, so people are still free to define stuff like "global filters" and use YAML anchors to reference them in probe configurations).
* probes live in `pidtree_bcc.probes` and can have their BPF code defined in either a class variable or a file with the same basename and the `.j2` (Jinja) extension (so editing it's easier).
* the main process loads all probes at startup and then spins them up in separate processes.
* event output is handled by a queue shared among probes: probes put stuff in, the main process reads it and writes it to the configured output file. This may not be the most performant of system because `multiprocessing.SimpleQueue` will always acquire a lock for every operation (while since we have a single consumer we could manage to only lock on writes and work with lower level pipes), but I benched this to reach around 115 KB/s of throughput, not impressive but enough for most use cases; it saves us from implementing a concurrent message passing system and risking of messing that up.

I still need to figure out what to implement in case a probe crashes. I'm probably more favourable to panic the whole program and let the operating system's _whateverd_ decide if respawn the process or not. Suggestions welcomed here.

Also, I'm trying to think about scenarios where the main process could crash leaving orphans. The `.get()` from a queue should never error out since it doesn't have a block timeout, so probably the only possibility is access to the outfile being broken. I will probably just end up wrapping the loop in an exception handler.