### PR TITLE
fix probe keepalive check

### DIFF
--- a/pidtree_bcc/main.py
+++ b/pidtree_bcc/main.py
@@ -93,8 +93,8 @@ def main(args: argparse.Namespace):
         probe_workers.append(Process(target=probe.start_polling))
         probe_workers[-1].start()
     try:
-        last_probe_check = time.time()
         while True:
+            last_probe_check = time.time()
             while time.time() - last_probe_check < PROBE_CHECK_PERIOD:
                 print(output_queue.get(), file=out)
                 out.flush()


### PR DESCRIPTION
When one indentation level makes the difference.
I wasn't updating `last_probe_check` after checking that the processes were alive so this results in the program going into an infinite loop without any output after 180 seconds.