### PR TITLE
network listener probe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 ---
 language: python
 python: ['3.5', '3.6', '3.7']
-install: sudo pip install tox-travis
+install: pip install tox-travis
 script: tox
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ username associated with the process.
   - Source IP `saddr`
   - Destination IP `daddr`
   - Destination port `port`
+- Full process tree attestation for IPv4 TCP/UDP listeners with the
+  same process metadata as above and
+  - Local bind address `laddr`
+  - Listening port `port`
+  - Network protocol `protocol` (e.g. tcp)
 - Optional plugin system for enriching events in userland
   - Included `sourceipmap` plugin for mapping source address
   - Included `loginuidmap` plugin for adding loginuid info to process tree
@@ -44,7 +49,7 @@ username associated with the process.
 ## Caveats
 * bcc compiles your eBPF "program" to bytecode at runtime,
   and as such needs the appropriate kernel headers installed on the host.
-* The current implementation only supports TCP and ipv4.
+* The current probe implementations only support IPv4.
 * The userland daemon is likely susceptible to interference or denial of
   service, however the main aim of the project is to reduce the MTTR for
   "business as usual" events - that is to make so engineers spend less time
@@ -70,7 +75,7 @@ pidtree-bcc to work.
 Pidtree-bcc implements a module probe system which allows multiple eBPF programs
 to be compiled and run in parallel. Probe loading is handled by the top-level keys
 in the configuration (see [`example_config.yml`](example_config.yml)).
-Currently, only the `tcp_connect` probe is implemented.
+Currently, this repository implements the `tcp_connect` and `net_listen` probes.
 
 ## Usage
 > CAUTION! The Makefile calls 'docker run' with `--priveleged`,
@@ -119,7 +124,8 @@ making TCP ipv4 `connect` syscalls like this one of me connecting to Freenode in
   "daddr": "185.30.166.37",
   "saddr": "X.X.X.X",
   "error": "",
-  "port": 6697
+  "port": 6697,
+  "probe": "tcp_connect"
 }
 ```
 

--- a/example_config.yml
+++ b/example_config.yml
@@ -3,19 +3,19 @@ tcp_connect:
   filters:
     - subnet_name: 10
       network: 10.0.0.0
-      network_mask : 255.0.0.0
+      network_mask: 255.0.0.0
       description: "all RFC 1918 10/8"
     - subnet_name: 17216
       network: 172.16.0.0
-      network_mask : 255.240.0.0
+      network_mask: 255.240.0.0
       description: "all RFC 1918 172.16/12"
     - subnet_name: 169254
       network: 169.254.0.0
-      network_mask : 255.255.0.0
+      network_mask: 255.255.0.0
       description: "all 169.254/16 loopback"
     - subnet_name: 127
       network: 127.0.0.0
-      network_mask : 255.0.0.0
+      network_mask: 255.0.0.0
       description: "all 127/8 loopback"
   plugins:
     sourceipmap:
@@ -23,3 +23,10 @@ tcp_connect:
       hostfiles:
         - '/etc/hosts'
       attribute_key: "source_host"
+net_listen:
+  protocols: [tcp]
+  excludeports:
+    - 22222
+    - 30000-40000
+  excludeaddress:
+    - 127.0.0.1

--- a/itest/example_config.yml
+++ b/itest/example_config.yml
@@ -37,3 +37,6 @@ tcp_connect:
       network: 127.0.0.0
       network_mask: 255.255.0.0
       description: "127.0/16 to get rid of the noise"
+net_listen:
+  excludeports:
+    - 31337

--- a/itest/itest.sh
+++ b/itest/itest.sh
@@ -56,6 +56,7 @@ function wait_for_tame_output {
   tail -n0 -f $OUTPUT_NAME | while read line; do
     if echo "$line" | grep "$1"; then
       echo "Caught test traffic matching '$1'"
+      pkill -x --parent $$ tail
       exit 0
     elif [ "$DEBUG" = "true" ]; then
       echo "DEBUG: \$line is $line"

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -1,0 +1,113 @@
+#include <net/sock.h>
+#include <bcc/proto.h>
+
+BPF_HASH(currsock, u32, struct sock*);
+BPF_PERF_OUTPUT(events);
+
+struct listen_bind_t {
+    u32 pid;
+    u32 laddr;
+    u16 port;
+    u8  protocol;
+};
+
+static u8 get_socket_protocol(struct sock *sk)
+{
+    // I'd love to be the one to have figured this out, I'm not
+    // https://github.com/iovisor/bcc/blob/v0.16.0/tools/tcpaccept.py#L115
+    u8 protocol;
+    int gso_max_segs_offset = offsetof(struct sock, sk_gso_max_segs);
+    int sk_lingertime_offset = offsetof(struct sock, sk_lingertime);
+    if (sk_lingertime_offset - gso_max_segs_offset == 4) {
+        protocol = *(u8 *)((u64)&sk->sk_gso_max_segs - 3);
+    } else {
+        protocol = *(u8 *)((u64)&sk->sk_wmem_queued - 3);
+    }
+    return protocol;
+}
+
+static void net_listen_event(struct pt_regs *ctx)
+{
+    u32 pid = bpf_get_current_pid_tgid();
+    struct sock** skp = currsock.lookup(&pid);
+    if (skp == 0) return;
+    int ret = PT_REGS_RC(ctx);
+    if (ret != 0) {
+        currsock.delete(&pid);
+        return;
+    }
+    u32 laddr = 0;
+    u16 port = 0;
+    struct sock* sk = *skp;
+    bpf_probe_read(&laddr, sizeof(u32), &sk->__sk_common.skc_rcv_saddr);
+    bpf_probe_read(&port, sizeof(u16), &sk->__sk_common.skc_num);
+
+    {% if excludeaddress or excludeports -%}
+    if (0
+    {% for addr in excludeaddress -%}
+        || laddr == {{ ip_to_int(addr) }}
+    {% endfor -%}
+    {% for port in excludeports -%}
+        {%- set port = port | string -%}
+        {% if '-' in port -%}
+            {%- set from_port, to_port = port.split('-') -%}
+            || (port >= {{ from_port }} && port <= {{ to_port }})
+        {% else -%}
+            || port == {{ port }}
+        {% endif -%}
+    {%- endfor -%}
+    ) {
+        currsock.delete(&pid);
+        return;
+    }
+    {% endif -%}
+
+    struct listen_bind_t listen = {};
+    listen.pid = pid;
+    listen.port = port;
+    listen.laddr = laddr;
+    listen.protocol = get_socket_protocol(sk);
+    events.perf_submit(ctx, &listen, sizeof(listen));
+    currsock.delete(&pid);
+}
+
+{% if 'udp' in protocols -%}
+int kprobe__inet_bind(
+    struct pt_regs *ctx,
+    struct socket *sock,
+    const struct sockaddr *addr,
+    int addrlen)
+{
+    struct sock* sk = sock->sk;
+    u8 protocol = get_socket_protocol(sk);
+    if (sk->__sk_common.skc_family == AF_INET && protocol == IPPROTO_UDP) {
+        u32 pid = bpf_get_current_pid_tgid();
+        currsock.update(&pid, &sk);
+    }
+    return 0;
+}
+
+int kretprobe__inet_bind(struct pt_regs *ctx)
+{
+    net_listen_event(ctx);
+    return 0;
+}
+{% endif -%}
+
+{% if 'tcp' in protocols -%}
+int kprobe__inet_listen(struct pt_regs *ctx, struct socket *sock, int backlog)
+{
+    struct sock* sk = sock->sk;
+    if (sk->__sk_common.skc_family == AF_INET) {
+        u32 pid = bpf_get_current_pid_tgid();
+        currsock.update(&pid, &sk);
+    }
+    return 0;
+}
+
+int kretprobe__inet_listen(struct pt_regs *ctx)
+{
+    net_listen_event(ctx);
+    return 0;
+}
+{% endif -%}

--- a/pidtree_bcc/probes/net_listen.py
+++ b/pidtree_bcc/probes/net_listen.py
@@ -31,7 +31,7 @@ class NetListenProbe(BPFProbe):
         """
         error = ''
         try:
-            proctree = list(crawl_process_tree(event.pid))
+            proctree = crawl_process_tree(event.pid)
         except Exception:
             error = traceback.format_exc()
             proctree = []

--- a/pidtree_bcc/probes/tcp_connect.py
+++ b/pidtree_bcc/probes/tcp_connect.py
@@ -23,7 +23,7 @@ class TCPConnectProbe(BPFProbe):
         """
         error = ''
         try:
-            proctree = list(crawl_process_tree(event.pid))
+            proctree = crawl_process_tree(event.pid)
         except Exception:
             error = traceback.format_exc()
             proctree = []

--- a/pidtree_bcc/utils.py
+++ b/pidtree_bcc/utils.py
@@ -3,29 +3,33 @@ import inspect
 import socket
 import struct
 import sys
-from typing import Generator
+from typing import List
 from typing import TextIO
 from typing import Type
 
 import psutil
 
 
-def crawl_process_tree(pid: int) -> Generator[dict, None, None]:
+def crawl_process_tree(pid: int) -> List[dict]:
     """ Takes a process and returns all process ancestry until the ppid is 0
 
     :param int pid: child process ID
     :return: yields dicts with pid, cmdline and username navigating up the tree
     """
+    result = []
     while True:
         if pid == 0:
             break
         proc = psutil.Process(pid)
-        yield {
-            'pid': proc.pid,
-            'cmdline': ' '.join(proc.cmdline()),
-            'username': proc.username(),
-        }
+        result.append(
+            {
+                'pid': proc.pid,
+                'cmdline': ' '.join(proc.cmdline()),
+                'username': proc.username(),
+            },
+        )
         pid = proc.ppid()
+    return result
 
 
 def smart_open(filename: str = None, mode: str = 'r') -> TextIO:

--- a/tests/net_listen_probe_test.py
+++ b/tests/net_listen_probe_test.py
@@ -1,34 +1,33 @@
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
-from pidtree_bcc.probes.tcp_connect import TCPConnectProbe
-from pidtree_bcc.utils import ip_to_int
+from pidtree_bcc.probes.net_listen import NetListenProbe
 
 
-@patch('pidtree_bcc.probes.tcp_connect.crawl_process_tree')
-def test_tcp_connect_enrich_event(mock_crawl):
-    probe = TCPConnectProbe(None)
+@patch('pidtree_bcc.probes.net_listen.crawl_process_tree')
+def test_net_listen_enrich_event(mock_crawl):
+    probe = NetListenProbe(None)
     mock_event = MagicMock(
         pid=123,
-        dport=80,
-        daddr=ip_to_int('1.1.1.1'),
-        saddr=ip_to_int('127.0.0.1'),
+        port=1337,
+        laddr=0,
+        protocol=6,
     )
     mock_crawl.return_value = [
-        {'pid': 123, 'cmdline': 'curl 1.1.1.1', 'username': 'foo'},
+        {'pid': 123, 'cmdline': 'nc -lp 1337', 'username': 'foo'},
         {'pid': 50, 'cmdline': 'bash', 'username': 'foo'},
         {'pid': 1, 'cmdline': 'init', 'username': 'root'},
     ]
     assert probe.enrich_event(mock_event) == {
         'pid': 123,
         'proctree': [
-            {'pid': 123, 'cmdline': 'curl 1.1.1.1', 'username': 'foo'},
+            {'pid': 123, 'cmdline': 'nc -lp 1337', 'username': 'foo'},
             {'pid': 50, 'cmdline': 'bash', 'username': 'foo'},
             {'pid': 1, 'cmdline': 'init', 'username': 'root'},
         ],
-        'daddr': '1.1.1.1',
-        'saddr': '127.0.0.1',
-        'port': 80,
+        'laddr': '0.0.0.0',
+        'port': 1337,
+        'protocol': 'tcp',
         'error': '',
     }
     mock_crawl.assert_called_once_with(123)

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -6,7 +6,7 @@ from pidtree_bcc import utils
 
 def test_crawl_process_tree():
     this_pid = os.getpid()
-    tree = list(utils.crawl_process_tree(this_pid))
+    tree = utils.crawl_process_tree(this_pid)
     assert len(tree) >= 1
     assert tree[0]['pid'] == this_pid
     assert tree[-1]['pid'] == 1  # should be init

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,36 +1,19 @@
 import os
 import sys
 
-import psutil
-import pytest
-
 from pidtree_bcc import utils
 
 
-@pytest.fixture
-def this_proc():
-    return psutil.Process(os.getpid())
-
-
-@pytest.fixture
-def this_pid():
-    return os.getpid()
-
-
-@pytest.fixture
-def this_file():
-    return os.path.abspath(__file__)
-
-
-def test_crawl_process_tree(this_proc, this_pid):
-    tree = utils.crawl_process_tree(this_proc)
-    assert type(tree) is list
+def test_crawl_process_tree():
+    this_pid = os.getpid()
+    tree = list(utils.crawl_process_tree(this_pid))
     assert len(tree) >= 1
-    assert tree[0].pid == this_pid
-    assert tree[-1].pid == 1  # should be init
+    assert tree[0]['pid'] == this_pid
+    assert tree[-1]['pid'] == 1  # should be init
 
 
-def test_smart_open(this_file):
+def test_smart_open():
+    this_file = os.path.abspath(__file__)
     assert utils.smart_open() == sys.stdout
     assert utils.smart_open('-') == sys.stdout
     assert utils.smart_open(this_file).name == this_file
@@ -39,3 +22,8 @@ def test_smart_open(this_file):
 def test_ip_to_int():
     assert utils.ip_to_int('127.0.0.1') == 16777343
     assert utils.ip_to_int('10.10.10.10') == 168430090
+
+
+def test_int_to_ip():
+    assert utils.int_to_ip(16777343) == '127.0.0.1'
+    assert utils.int_to_ip(168430090) == '10.10.10.10'


### PR DESCRIPTION
Oof, I probably spent more time for making the itest consistent than for the probe itself.
Anyhow, this is my first stab a implementing a probe which catch things starting to listen. The general idea is:
* TCP sockets will have to go though `listen`
* UDP sockets will need port binding via `bind`

so I'm treating those cases as separate probes, filtering out everything which is TCP from the `bind` one.
I don't know if something other than TCP sockets use `listen`, but I'll confess I let the door open (i.e. not making a strict check on protocol) because I'm curious to find out.
I also implemented some very easy filtering to allow selecting a protocol or excluding ports and addresses (e.g. if you don't want to log stuff binding to 127.0.0.1).

I will probably implement some kind of sidecar which can periodically run like `ss something something` to also have visility of long running stuff, but want to get this out first.

The notable changes I made to itests is that I generalized a bunch of functions and then swapped the output named pipe with a regular file so that it does not break when readers open and close it.