### PR TITLE
test with BCC v0.17.0, add packaging for Ubuntu Focal

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 ARG     OS_RELEASE=bionic
 FROM    ubuntu:${OS_RELEASE} as builder
-ARG     BCC_VERSION=0.12.0
+ARG     BCC_VERSION=0.17.0
 
 RUN     apt-get update \
-        && apt-get -y install pbuilder aptitude git \
+        && DEBIAN_FRONTEND=noninteractive apt-get -y install pbuilder aptitude git \
         && apt-get clean
 
 # Clone source code
@@ -21,7 +21,7 @@ RUN     /usr/lib/pbuilder/pbuilder-satisfydepends && ./scripts/build-deb.sh rele
 FROM    ubuntu:${OS_RELEASE}
 
 RUN     apt-get update \
-        && apt-get -y install \
+        && DEBIAN_FRONTEND=noninteractive apt-get -y install \
             python3 \
             python3-pip \
         && apt-get clean

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ FIFO = $(CURDIR)/pidtree-bcc.fifo
 EXTRA_DOCKER_ARGS ?=
 DOCKER_ARGS = $(EXTRA_DOCKER_ARGS) -v /etc/passwd:/etc/passwd:ro --privileged --cap-add sys_admin --pid host
 HOST_OS_RELEASE = $(or $(shell cat /etc/lsb-release 2>/dev/null | grep -Po '(?<=CODENAME=)(.+)'), bionic)
+SUPPORTED_UBUNTU_RELEASES = xenial bionic focal
 
 default: venv
 
@@ -51,12 +52,11 @@ test: clean-cache
 	tox
 
 test-all: clean-cache
+	set -e
 	make test
 	make itest
-	make package_ubuntu_xenial
-	make package_ubuntu_bionic
-	make itest_ubuntu_xenial
-	make itest_ubuntu_bionic
+	$(foreach release, $(SUPPORTED_UBUNTU_RELEASES), make package_ubuntu_$(release);)
+	$(foreach release, $(SUPPORTED_UBUNTU_RELEASES), make itest_ubuntu_$(release);)
 
 package_%:
 	make -C packaging package_$*

--- a/itest/Dockerfile.ubuntu
+++ b/itest/Dockerfile.ubuntu
@@ -1,9 +1,9 @@
 ARG     OS_RELEASE
 FROM    ubuntu:${OS_RELEASE} as builder
-ARG     BCC_VERSION=0.12.0
+ARG     BCC_VERSION=0.17.0
 
 RUN     apt-get update \
-        && apt-get -y install pbuilder aptitude git \
+        && DEBIAN_FRONTEND=noninteractive apt-get -y install pbuilder aptitude git \
         && apt-get clean
 
 # Clone source code

--- a/itest/itest.sh
+++ b/itest/itest.sh
@@ -76,10 +76,6 @@ function wait_for_tame_output {
 }
 
 function main {
-  if [[ $# -ne 1 && "$1" != "docker" && "$1" != "ubuntu_xenial" && "$1" != "ubuntu_bionic" ]]; then
-    echo "ERROR: '$@' is not a supported argument (see 'itest/itest.sh' for options)" >&2
-    exit 1
-  fi
   trap cleanup EXIT
   is_port_used $TEST_CONNECT_PORT
   is_port_used $TEST_LISTEN_PORT
@@ -103,7 +99,7 @@ function main {
         -v $TOPLEVEL/itest/example_config.yml:/work/config.yml \
         -v $TOPLEVEL/$OUTPUT_NAME:/work/outfile \
         pidtree-itest -c /work/config.yml -f /work/outfile
-  elif [[ "$1" = "ubuntu_xenial" || "$1" = "ubuntu_bionic" ]]; then
+  elif [[ "$1" =~ ^ubuntu_[a-z]+$ ]]; then
     if [ -f /etc/lsb-release ]; then
       source /etc/lsb-release
     else
@@ -121,6 +117,9 @@ function main {
         -v $TOPLEVEL/itest/dist/$1/:/work/dist \
         -v $TOPLEVEL/itest/deb_package_itest.sh:/work/deb_package_itest.sh \
         pidtree-itest-$1 /work/deb_package_itest.sh run -c /work/config.yml -f /work/outfile
+  else
+    echo "ERROR: '$@' is not a supported argument (see 'itest/itest.sh' for options)" >&2
+    exit 1
   fi
   echo "Sleeping $SPIN_UP_TIME seconds for pidtree-bcc to start"
   sleep $SPIN_UP_TIME

--- a/packaging/Dockerfile.ubuntu
+++ b/packaging/Dockerfile.ubuntu
@@ -1,7 +1,15 @@
 ARG     OS_RELEASE
 FROM    ubuntu:${OS_RELEASE}
 
-RUN     apt-get update && apt-get -y install \
+# Focal doesn't have dh-virtualenv in default repos
+# so we install it from the maintainer's PPA
+RUN     if grep focal /etc/lsb-release; then \
+            apt-get update \
+            && DEBIAN_FRONTEND=noninteractive apt-get -y install software-properties-common \
+            && add-apt-repository ppa:jyrki-pulliainen/dh-virtualenv; \
+        fi
+
+RUN     apt-get update && DEBIAN_FRONTEND=noninteractive apt-get -y install \
             python3 \
             python3-pip \
             dh-virtualenv \


### PR DESCRIPTION
This should futureproof us for a while.
I'm still waiting for all itests to finish locally (because BCC takes forever to compile), but I tested them working for `focal`, so I'm fairly confident it should still be alright for other distros as well (Travis will tell anyhow). 