### PR TITLE
normalize "excludeports" and "includeports" settings for all probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,10 @@ Would mean filter out all traffic from 10.0.0.0/8 except for that on port 80. If
 to include_ports, then it would filter out only traffic to 10.0.0.0/8 on port 80.
 
 In addition, you can add a global config for filtering out all traffic except those for specific ports,
-using the option `includeports`.
+using the option `includeports`. There also exists the specular global probe config `excludeports` which
+allows to specify a list of ports or port ranges to exclude from event capturing. These parameters are
+avilable for all currently implement probes (`tcp_connect`, `net_listen` and `udp_session`) and are mutually
+exclusive. If both are speficied for a single probe, `includeports` will have precendence.
 
 ## Plugins
 Plugin configuration is populated using the `plugins` key at the top level of the probe configuration:

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -30,25 +30,23 @@ static void net_listen_event(struct pt_regs *ctx)
     bpf_probe_read(&laddr, sizeof(u32), &sk->__sk_common.skc_rcv_saddr);
     bpf_probe_read(&port, sizeof(u16), &sk->__sk_common.skc_num);
 
-    {% if excludeaddress or excludeports -%}
+    {% if excludeaddress -%}
     if (0
-    {% for addr in excludeaddress -%}
+    {%- for addr in excludeaddress %}
         || laddr == {{ ip_to_int(addr) }}
     {% endfor -%}
-    {% for port in excludeports -%}
-        {%- set port = port | string -%}
-        {% if '-' in port -%}
-            {%- set from_port, to_port = port.split('-') -%}
-            || (port >= {{ from_port }} && port <= {{ to_port }})
-        {% else -%}
-            || port == {{ port }}
-        {% endif -%}
-    {%- endfor -%}
     ) {
         currsock.delete(&pid);
         return;
     }
     {% endif -%}
+
+    {% if includeports or excludeports -%}
+    {{ utils.include_exclude_ports(includeports, excludeports, 'port') | indent(4) }} {
+        currsock.delete(&pid);
+        return;
+    }
+    {%- endif %}
 
     struct listen_bind_t listen = {};
     listen.pid = pid;

--- a/pidtree_bcc/probes/tcp_connect.j2
+++ b/pidtree_bcc/probes/tcp_connect.j2
@@ -40,19 +40,18 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
     u16 dport = 0;
     bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
     bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+
     {{ utils.net_filter_if_excluded(filters) | indent(4) }} {
         currsock.delete(&pid);
         return 0;
     }
-    {% if includeports != []: -%}
-    if ( 1
-    {% for port in includeports -%}
-        && ntohs({{ port }}) != dport
-    {% endfor %}) {
+
+    {% if includeports or excludeports -%}
+    {{ utils.include_exclude_ports(includeports, excludeports, 'ntohs(dport)') | indent(4) }} {
         currsock.delete(&pid);
         return 0;
     }
-    {% endif -%}
+    {%- endif %}
 
     bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
 

--- a/pidtree_bcc/probes/tcp_connect.py
+++ b/pidtree_bcc/probes/tcp_connect.py
@@ -13,6 +13,7 @@ class TCPConnectProbe(BPFProbe):
         'ip_to_int': ip_to_int,
         'filters': [],
         'includeports': [],
+        'excludeports': [],
     }
 
     def enrich_event(self, event: Any) -> dict:

--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -44,6 +44,13 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
         return 0;
     }
 
+    {% if includeports or excludeports -%}
+    {{ utils.include_exclude_ports(includeports, excludeports, 'ntohs(dport)') | indent(4) }} {
+        currsock.delete(&pid);
+        return 0;
+    }
+    {%- endif %}
+
     // Check if we are already tracing this session
     u32 pid = bpf_get_current_pid_tgid();
     struct udp_socket_tuple sock_tuple = {};

--- a/pidtree_bcc/probes/udp_session.py
+++ b/pidtree_bcc/probes/udp_session.py
@@ -21,6 +21,8 @@ class UDPSessionProbe(BPFProbe):
     CONFIG_DEFAULTS = {
         'ip_to_int': ip_to_int,
         'filters': [],
+        'includeports': [],
+        'excludeports': [],
     }
     SESSION_MAX_DURATION_DEFAULT = 120
     SESSION_START = 1

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -55,3 +55,23 @@ if (0 // for easier templating
     )
 {% endfor %})
 {%- endmacro %}
+
+{% macro include_exclude_ports(includeports, excludeports, port_var='dport') -%}
+{% if includeports %}
+if (1
+{%- for port in includeports %}
+    && {{ port }} != {{ port_var }}
+{% endfor %})
+{% else -%}
+if (0
+{%- for port in excludeports %}
+    {% set port = port | string -%}
+    {% if '-' in port -%}
+        {%- set from_port, to_port = port.split('-') -%}
+        || ({{ port_var }} >= {{ from_port }} && {{ port_var }} <= {{ to_port }})
+    {%- else -%}
+        || {{ port_var }} == {{ port }}
+    {%- endif %}
+{% endfor %})
+{% endif -%}
+{%- endmacro %}


### PR DESCRIPTION
Pretty much what the title says, to reduce configuration ambiguity from one probe to the other.