### PR TITLE
Simplify udp session tracing key

### DIFF
--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -8,11 +8,6 @@
 
 {{ utils.net_filter_masks(filters, ip_to_int) }}
 
-struct udp_socket_tuple {
-    u32 pid;
-    u64 sock_pointer;
-};
-
 struct udp_session_event {
     u8  type;
     u32 pid;
@@ -22,7 +17,7 @@ struct udp_session_event {
 };
 
 BPF_PERF_OUTPUT(events);
-BPF_HASH(tracing, struct udp_socket_tuple, u8);
+BPF_HASH(tracing, u64, u8);
 
 {{ utils.get_proto_func() }}
 
@@ -51,24 +46,22 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
     {%- endif %}
 
     // Check if we are already tracing this session
-    u32 pid = bpf_get_current_pid_tgid();
-    struct udp_socket_tuple sock_tuple = {};
-    sock_tuple.pid = pid;
-    sock_tuple.sock_pointer = (u64) sk;
-    u8 trace_flag = tracing.lookup(&sock_tuple) != 0 ? SESSION_CONTINUE : SESSION_START;
+    u64 sock_pointer = (u64) sk;
+    u8 trace_flag = tracing.lookup(&sock_pointer) != 0 ? SESSION_CONTINUE : SESSION_START;
 
+    u32 pid = bpf_get_current_pid_tgid();
     struct udp_session_event session = {};
     session.pid = pid;
     session.type = trace_flag;
-    session.sock_pointer = sock_tuple.sock_pointer;
+    session.sock_pointer = sock_pointer;
     bpf_probe_read(&session.daddr, sizeof(u32), &daddr);
     bpf_probe_read(&session.dport, sizeof(u16), &dport);
     session.dport = ntohs(session.dport);
     events.perf_submit(ctx, &session, sizeof(session));
     if(trace_flag == SESSION_START) {
         // We don't care about the actual value in the map
-        // any u8 var would be fine
-        tracing.update(&sock_tuple, &trace_flag);
+        // any u8 var != 0 would be fine
+        tracing.update(&sock_pointer, &trace_flag);
     }
 
     return 0;
@@ -80,17 +73,15 @@ int kprobe__inet_release(struct pt_regs *ctx, struct socket *sock) {
     u8 protocol = get_socket_protocol(sock->sk);
     if(protocol != IPPROTO_UDP) return 0;
 
-    u32 pid = bpf_get_current_pid_tgid();
-    struct udp_socket_tuple sock_tuple = {};
-    sock_tuple.pid = pid;
-    sock_tuple.sock_pointer = (u64) sock->sk;
-    if(tracing.lookup(&sock_tuple) != 0) {
+    u64 sock_pointer = (u64) sock->sk;
+    if(tracing.lookup(&sock_pointer) != 0) {
+        u32 pid = bpf_get_current_pid_tgid();
         struct udp_session_event session = {};
         session.pid = pid;
         session.type = SESSION_END;
-        session.sock_pointer = sock_tuple.sock_pointer;
+        session.sock_pointer = sock_pointer;
         events.perf_submit(ctx, &session, sizeof(session));
-        tracing.delete(&sock_tuple);
+        tracing.delete(&sock_pointer);
     }
     return 0;
 }

--- a/tests/udp_session_probe_test.py
+++ b/tests/udp_session_probe_test.py
@@ -57,9 +57,9 @@ def test_udp_session_expiration_worker(mock_time):
     mock_time.monotonic.return_value = 200
     probe = UDPSessionProbe(None)
     probe.session_tracking = {
-        (1, 1): {'last_update': 180},
-        (2, 2): {'last_update': 0},
-        (3, 3): {'last_update': 190},
+        1: {'last_update': 180},
+        2: {'last_update': 0},
+        3: {'last_update': 190},
     }
     with patch.object(probe, '_process_events') as mock_process:
         # never_crash uses functools.wraps so we can extract the wrapped method
@@ -70,5 +70,5 @@ def test_udp_session_expiration_worker(mock_time):
             # so we need to pass `probe` as `self`
             undecorated_method(probe, 120)
         mock_process.assert_called_once_with(
-            None, SessionEventWrapper(3, 2, 2), None, False,
+            None, SessionEventWrapper(3, 2), None, False,
         )


### PR DESCRIPTION
There are some cases (like `nslookup`) in which the process which will send data over a socket is different from the one which will release it. This effectively breaks the UDP session tracking as the key `(pid, sock_pointer)` will not match.

To address that, I simplified the tracking key to only include the socket pointer. This will still maintain the expected behaviour as the pointer to the sock struct derives from an entry in the kernel's file descriptor table and should hence be globally unique (this assumption comes from reading a bunch of the kernel code which handles the passage from integer socket file descriptor to sock pointer and by manually testing the new code for a bit to check for any strange behaviour).

I also added an extra check for the presence of the sock pointer in the userland tracking map. It is basically never possible that an event is reported without it already being tracked, but in the unlikely case a socket remains open for very long without sending messages, gets removed from the map by the "expiration worker" and then gets actually closed, the probe won't crash.