### PR TITLE
standardize ip-port filtering for net_listen probe

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -30,8 +30,11 @@ tcp_connect:
 net_listen:
   snapshot_periodicity: 43200
   protocols: [tcp]
+  filters:
+    - subnet_name: 127
+      network: 127.0.0.0
+      network_mask: 255.0.0.0
+      description: "all 127/8 loopback"
   excludeports:
     - 22222
     - 30000-40000
-  excludeaddress:
-    - 127.0.0.1

--- a/itest/itest.sh
+++ b/itest/itest.sh
@@ -15,10 +15,11 @@ TIMEOUT=$(( SPIN_UP_TIME + 5 ))
 # Format: test_name:test_event_generator:test_flag_to_match:exit_code
 TEST_CASES=(
   "tcp_connect:create_connect_event $TEST_PORT_1:nc -w 1 127.1.33.7 $TEST_PORT_1:0"
-  "net_listen:create_listen_event $TEST_PORT_2:nc -w $TEST_LISTEN_TIMEOUT -lnp $TEST_PORT_2:0"
+  "net_listen:create_listen_event $TEST_PORT_2 127.1.33.7:nc -w $TEST_LISTEN_TIMEOUT -lnp $TEST_PORT_2:0"
   "udp_session:create_udp_event $TEST_PORT_1:nc -w 1 -u 127.1.33.7 $TEST_PORT_1:0"
   "tcp_connect_exclude:create_connect_event $TEST_PORT_2:nc -w 1 127.1.33.7 $TEST_PORT_2:124"
   "udp_session_exclude:create_udp_event $TEST_PORT_2:nc -w 1 -u 127.1.33.7 $TEST_PORT_2:124"
+  "net_listen_filter:create_listen_event $TEST_PORT_2 127.0.0.1:nc -w $TEST_LISTEN_TIMEOUT -lnp $TEST_PORT_2:124"
 )
 
 function is_port_used {
@@ -42,7 +43,7 @@ function create_connect_event {
 function create_listen_event {
   echo "Creating test listener"
   sleep 1
-  nc -w $TEST_LISTEN_TIMEOUT -lnp $1 2> /dev/null
+  nc -w $TEST_LISTEN_TIMEOUT -lnp $1 -s $2 2> /dev/null
 }
 
 function create_udp_event {

--- a/itest/itest_config.yml
+++ b/itest/itest_config.yml
@@ -42,6 +42,7 @@ tcp_connect:
   excludeports:
     - <port2>
 net_listen:
+  filters: *net_filters
   excludeports:
     - <port1>
 udp_session:

--- a/pidtree_bcc/filtering.py
+++ b/pidtree_bcc/filtering.py
@@ -1,0 +1,49 @@
+from collections import namedtuple
+from typing import List
+from typing import Union
+
+from pidtree_bcc.utils import ip_to_int
+
+
+IpPortFilter = namedtuple('IpPortFilter', ('subnet', 'netmask', 'except_ports', 'include_ports'))
+
+
+class NetFilter:
+
+    def __init__(self, filters: List[dict]):
+        """ Constructor
+
+        :param List[dict] filters: list of IP-ports filters. Format:
+                                   {
+                                       'network': '127.0.0.1',
+                                       'network_mask': '255.0.0.0',
+                                       'except_ports': [123, 456], # optional
+                                       'include_ports': [789],     # optional
+                                   }
+        """
+        self.filters = [
+            IpPortFilter(
+                ip_to_int(f['network']) & ip_to_int(f['network_mask']),
+                ip_to_int(f['network_mask']),
+                set(map(int, f.get('except_ports', []))),
+                set(map(int, f.get('include_ports', []))),
+            ) for f in filters
+        ]
+
+    def is_filtered(self, ip_address: Union[int, str], port: int) -> bool:
+        """ Check if IP-port combination is filtered
+
+        :param Union[int, str] ip_address: IP address in integer or string form
+        :param int port: port in host byte order representation (i.e. pre htons / after ntohs)
+        :return: True if filtered
+        """
+        if isinstance(ip_address, str):
+            ip_address = ip_to_int(ip_address)
+        for f in self.filters:
+            if (
+                f.netmask & ip_address == f.subnet
+                and port not in f.except_ports
+                and (not f.include_ports or port in f.include_ports)
+            ):
+                return True
+        return False

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -2,6 +2,8 @@
 #include <net/sock.h>
 #include <bcc/proto.h>
 
+{{ utils.net_filter_masks(filters, ip_to_int) }}
+
 BPF_HASH(currsock, u32, struct sock*);
 BPF_PERF_OUTPUT(events);
 
@@ -30,12 +32,8 @@ static void net_listen_event(struct pt_regs *ctx)
     bpf_probe_read(&laddr, sizeof(u32), &sk->__sk_common.skc_rcv_saddr);
     bpf_probe_read(&port, sizeof(u16), &sk->__sk_common.skc_num);
 
-    {% if excludeaddress -%}
-    if (0
-    {%- for addr in excludeaddress %}
-        || laddr == {{ ip_to_int(addr) }}
-    {% endfor -%}
-    ) {
+    {% if filters -%}
+    {{ utils.net_filter_if_excluded(filters, 'laddr', 'ntohs(port)') | indent(4) }} {
         currsock.delete(&pid);
         return;
     }

--- a/tests/filtering_test.py
+++ b/tests/filtering_test.py
@@ -1,0 +1,46 @@
+import pytest
+
+from pidtree_bcc.filtering import NetFilter
+from pidtree_bcc.utils import ip_to_int
+
+
+@pytest.fixture
+def net_filtering():
+    return NetFilter(
+        [
+            {
+                'network': '127.0.0.1',
+                'network_mask': '255.0.0.0',
+            },
+            {
+                'network': '10.0.0.0',
+                'network_mask': '255.0.0.0',
+                'except_ports': [123],
+            },
+            {
+                'network': '192.168.0.0',
+                'network_mask': '255.255.0.0',
+                'include_ports': [123],
+            },
+        ],
+    )
+
+
+def test_filter_ip_int(net_filtering):
+    assert net_filtering.is_filtered(ip_to_int('127.1.33.7'), 80)
+    assert not net_filtering.is_filtered(ip_to_int('1.2.3.4'), 80)
+
+
+def test_filter_ip_str(net_filtering):
+    assert net_filtering.is_filtered('127.1.33.7', 80)
+    assert not net_filtering.is_filtered('1.2.3.4', 80)
+
+
+def test_filter_ip_except_port(net_filtering):
+    assert net_filtering.is_filtered('10.1.2.3', 80)
+    assert not net_filtering.is_filtered('10.1.2.3', 123)
+
+
+def test_filter_ip_include_port(net_filtering):
+    assert net_filtering.is_filtered('192.168.0.1', 123)
+    assert not net_filtering.is_filtered('192.168.0.1', 80)


### PR DESCRIPTION
This just modifies the `net_listen` probe to use the same `filters` configuration structure as the other probes so that it is easily possible to filter out entire network blocks.