### PR TITLE
Net listen namespace filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ username associated with the process.
 
 ## Dependencies
 See the installation instructions for [bcc](https://github.com/iovisor/bcc).
-It is required for the `python3-bcc` package and its depedencies to be installed.
+It is required for the `python3-bcc` package and its dependencies to be installed.
 
 Most notably, you need a kernel with eBPF enabled (4.4 onward) and the
 Linux headers for your running kernel version installed. For a
@@ -77,7 +77,7 @@ pidtree-bcc to work.
 ## Probes
 Pidtree-bcc implements a modular probe system which allows multiple eBPF programs
 to be compiled and run in parallel. Probe loading is handled via the top-level keys
-in the configuration (see [`example_config.yml`](example_config.yml)).
+in the configuration (see [`example_config.yml`](example_config.yml) for inline documentation).
 
 Currently, this repository implements the `tcp_connect`, `net_listen` and `udp_session` probes.
 It is possible to extend this system with external packages via the `--extra-probe-path`
@@ -141,7 +141,7 @@ or 172.16/12 ranges because of the subnet filters I've included in the
 list of addresses you might want to filter, so you can use the example
 configuration to write your own.
 
-Additionally, you can make the filters apply only to certain ports, using except_ports and include_ports.
+Additionally, you can make the filters apply only to certain ports, using `except_ports` and `include_ports`.
 For example:
 
 ```yaml

--- a/example_config.yml
+++ b/example_config.yml
@@ -1,9 +1,11 @@
 ---
 _net_filters: &net_filters
-  - subnet_name: 10
-    network: 10.0.0.0
-    network_mask: 255.0.0.0
-    description: "all RFC 1918 10/8"
+  - subnet_name: 10                       # name for the filter (must be unique)
+    network: 10.0.0.0                     # network address in dot-notation
+    network_mask: 255.0.0.0               # network mask in dot-notation
+    description: "all RFC 1918 10/8"      # just a human readable description
+    # except_ports: [443]                 # do not filter traffic for this set of ports
+    # include_ports: [80]                 # only filters traffic for this set of ports
   - subnet_name: 17216
     network: 172.16.0.0
     network_mask: 255.240.0.0
@@ -17,6 +19,14 @@ _net_filters: &net_filters
     network_mask: 255.0.0.0
     description: "all 127/8 loopback"
 
+
+# Some configuration fields supported by all probes:
+#   filters: list of network filters (see above for schema); they act on the destination
+#            address for tcp_connect and udp_session, local listening address for net_listen
+#   excludeports: list of ports to be filtered out (cannot be used with includeports)
+#   includeports: list of ports for which events will be logged (filters out all the others) (cannot be used with excludeports)
+#   plugins: map of plugins to enable for the probe (check README for more details)
+
 udp_session:
   filters: *net_filters
 tcp_connect:
@@ -28,9 +38,9 @@ tcp_connect:
         - '/etc/hosts'
       attribute_key: "source_host"
 net_listen:
-  snapshot_periodicity: 43200
-  protocols: [tcp]
-  same_namespace_only: False
+  snapshot_periodicity: 43200     # how often the probe should output a full list of the listening processes (seconds, off by default)
+  protocols: [tcp]                # for which protocols events get logged (choices: tcp, udp)
+  same_namespace_only: False      # filter out events for network namespaces different from the one of the pidtree-bcc process (off by default)
   filters:
     - subnet_name: 127
       network: 127.0.0.0

--- a/example_config.yml
+++ b/example_config.yml
@@ -30,6 +30,7 @@ tcp_connect:
 net_listen:
   snapshot_periodicity: 43200
   protocols: [tcp]
+  same_namespace_only: False
   filters:
     - subnet_name: 127
       network: 127.0.0.0

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -46,6 +46,13 @@ static void net_listen_event(struct pt_regs *ctx)
     }
     {%- endif %}
 
+    {% if net_namespace -%}
+    if (sk->__sk_common.skc_net.net->ns.inum != {{ net_namespace }}) {
+        currsock.delete(&pid);
+        return;
+    }
+    {%- endif %}
+
     struct listen_bind_t listen = {};
     listen.pid = pid;
     listen.port = port;

--- a/pidtree_bcc/utils.py
+++ b/pidtree_bcc/utils.py
@@ -2,6 +2,7 @@ import functools
 import importlib
 import inspect
 import logging
+import os
 import socket
 import struct
 import sys
@@ -111,3 +112,19 @@ def never_crash(func: Callable) -> Callable:
             except Exception as e:
                 logging.error('Error executing {}: {}'.format(func.__name__, e))
     return wrapper
+
+
+def get_network_namespace(pid: int = None) -> int:
+    """ Get network namespace identifier
+
+    :param int pid: process ID (if not provided selects calling process)
+    :return: network namespace inum
+    """
+    if not pid:
+        pid = 'self'
+    try:
+        ns_link = str(os.readlink('/proc/{}/ns/net'.format(pid)))
+        # format will be "net:[<inum>]"
+        return int(ns_link.strip()[5:-1])
+    except Exception:
+        return None

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -1,5 +1,7 @@
 import os
 import sys
+from unittest.mock import call
+from unittest.mock import patch
 
 from pidtree_bcc import utils
 
@@ -27,3 +29,16 @@ def test_ip_to_int():
 def test_int_to_ip():
     assert utils.int_to_ip(16777343) == '127.0.0.1'
     assert utils.int_to_ip(168430090) == '10.10.10.10'
+
+
+@patch('pidtree_bcc.utils.os')
+def test_get_network_namespace(mock_os):
+    mock_os.readlink.return_value = 'net:[456]'
+    assert utils.get_network_namespace() == 456
+    assert utils.get_network_namespace(123) == 456
+    mock_os.readlink.assert_has_calls([
+        call('/proc/self/ns/net'),
+        call('/proc/123/ns/net'),
+    ])
+    mock_os.readlink.side_effect = Exception
+    assert utils.get_network_namespace() is None


### PR DESCRIPTION
This add the option for the `net_listen` probe to only log event happening on the same network namespace of the pidtree-bcc process. This can be useful to filter out noise generated by things like Docker containers.