### PR TITLE
option to filter out randomly bound ports in net_listen

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -41,6 +41,7 @@ net_listen:
   snapshot_periodicity: 43200     # how often the probe should output a full list of the listening processes (seconds, off by default)
   protocols: [tcp]                # for which protocols events get logged (choices: tcp, udp)
   same_namespace_only: False      # filter out events for network namespaces different from the one of the pidtree-bcc process (off by default)
+  exclude_random_bind: False      # filter out bind events using port 0 (affects UDP events only, off by default)
   filters:
     - subnet_name: 127
       network: 127.0.0.0

--- a/itest/itest_config.yml
+++ b/itest/itest_config.yml
@@ -43,6 +43,7 @@ tcp_connect:
     - <port2>
 net_listen:
   filters: *net_filters
+  exclude_random_bind: True
   excludeports:
     - <port1>
 udp_session:

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -69,6 +69,12 @@ int kprobe__inet_bind(
     const struct sockaddr *addr,
     int addrlen)
 {
+    {% if exclude_random_bind -%}
+    struct sockaddr_in* inet_addr = (struct sockaddr_in*)addr;
+    if (inet_addr->sin_port == 0) {
+        return 0;
+    }
+    {% endif -%}
     struct sock* sk = sock->sk;
     u8 protocol = get_socket_protocol(sk);
     if (sk->__sk_common.skc_family == AF_INET && protocol == IPPROTO_UDP) {
@@ -83,7 +89,7 @@ int kretprobe__inet_bind(struct pt_regs *ctx)
     net_listen_event(ctx);
     return 0;
 }
-{% endif -%}
+{%- endif %}
 
 {% if 'tcp' in protocols -%}
 int kprobe__inet_listen(struct pt_regs *ctx, struct socket *sock, int backlog)

--- a/pidtree_bcc/probes/net_listen.py
+++ b/pidtree_bcc/probes/net_listen.py
@@ -36,6 +36,7 @@ class NetListenProbe(BPFProbe):
         'includeports': [],
         'snapshot_periodicity': False,
         'same_namespace_only': False,
+        'exclude_random_bind': False,
     }
     SUPPORTED_PROTOCOLS = ('udp', 'tcp')
 


### PR DESCRIPTION
Useful to filter out some noisy events (e.g. DNS lookups which listen before sending :wat:)