### PR TITLE
generalize base docker images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG     OS_RELEASE=bionic
-FROM    ubuntu:${OS_RELEASE} as builder
+FROM    pidtree-docker-base-${OS_RELEASE} as builder
 ARG     BCC_VERSION=0.19.0
 
 RUN     apt-get update \
@@ -18,7 +18,7 @@ RUN     /usr/lib/pbuilder/pbuilder-satisfydepends && ./scripts/build-deb.sh rele
 
 
 #----------------------------------------------------------------------------------------------
-FROM    ubuntu:${OS_RELEASE}
+FROM    pidtree-docker-base-${OS_RELEASE}
 
 RUN     apt-get update \
         && DEBIAN_FRONTEND=noninteractive apt-get -y install \

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -1,0 +1,2 @@
+ARG     BASE_IMAGE=ubuntu:bionic
+FROM    ${BASE_IMAGE}

--- a/README.md
+++ b/README.md
@@ -257,3 +257,6 @@ tree nodes. The info will be stored in the `loginuid` and `loginname` fields.
   avoid "stealing" performance from the main probe process.
 * Most of the code is self-documenting, so if something is not clear, try to look in the
   docstrings.
+* It is possible to use private Docker base images for testing by setting the environment
+  variable `DOCKER_BASE_IMAGE_TMPL`. This is expected to contain the substring "OS_RELEASE_PH"
+  which will be replaced by the targeted OS release codenames.

--- a/itest/Dockerfile.ubuntu
+++ b/itest/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 ARG     OS_RELEASE
-FROM    ubuntu:${OS_RELEASE} as builder
+FROM    pidtree-docker-base-${OS_RELEASE} as builder
 ARG     BCC_VERSION=0.19.0
 
 RUN     apt-get update \
@@ -17,7 +17,7 @@ RUN     sed -i 's/git describe --abbrev=0/git describe --tags --abbrev=0/' scrip
 RUN     /usr/lib/pbuilder/pbuilder-satisfydepends && ./scripts/build-deb.sh release
 
 #----------------------------------------------------------------------------------------------
-FROM    ubuntu:${OS_RELEASE}
+FROM    pidtree-docker-base-${OS_RELEASE}
 ARG     HOSTRELEASE
 # Second definition of OS_RELEASE because it gets lost after FROM statement
 ARG     OS_RELEASE

--- a/packaging/Dockerfile.ubuntu
+++ b/packaging/Dockerfile.ubuntu
@@ -1,5 +1,5 @@
 ARG     OS_RELEASE
-FROM    ubuntu:${OS_RELEASE}
+FROM    pidtree-docker-base-${OS_RELEASE}
 
 # Focal doesn't have dh-virtualenv in default repos
 # so we install it from the maintainer's PPA


### PR DESCRIPTION
This allow to quickly switch all base images in cases there the need to use a different image registry.