### PR TITLE
network filters into bpf trie map

### DIFF
--- a/pidtree_bcc/ctypes_helper.py
+++ b/pidtree_bcc/ctypes_helper.py
@@ -1,0 +1,51 @@
+"""
+Some utilities instrumenting ctypes declaration to make them more
+"object-oriented friendly", mostly to facilitate testing.
+"""
+import ctypes
+
+
+class ComparableCtStructure(ctypes.Structure):
+    """ Just a wrapper for ctypes structs, but comparable and printable """
+
+    def __eq__(self, other) -> bool:
+        for field in self._fields_:
+            if getattr(self, field[0]) != getattr(other, field[0]):
+                return False
+        return True
+
+    def __ne__(self, other) -> bool:
+        return not self.__eq__(other)
+
+    def __repr__(self) -> str:
+        fields = ('{}={}'.format(field[0], getattr(self, field[0])) for field in self._fields_)
+        return '{}({})'.format(self.__class__.__name__, ', '.join(fields))
+
+
+def create_comparable_array_type(size: int, element_type: 'ctypes._CData') -> 'ctypes._CData':
+    """ Create instrumented ctypes array type to allow comparisons (and prints nicely)
+
+    :param int size: size of the array
+    :param ctypes._CData element_type: Ctype of the array elements
+    :return: array Ctype
+    """
+
+    def repr_method(self) -> str:
+        return '{}({})'.format(self.__class__.__name__, ', '.join(str(e) for e in self))
+
+    def eq_method(self, other) -> bool:
+        if len(self) != len(other):
+            return False
+        for a, b in zip(self, other):
+            if a != b:
+                return False
+        return True
+
+    def neq_method(self, other) -> bool:
+        return not self.__eq__(other)
+
+    array_type = size * element_type
+    array_type.__repr__ = repr_method
+    array_type.__eq__ = eq_method
+    array_type.__neq__ = neq_method
+    return array_type

--- a/pidtree_bcc/filtering.py
+++ b/pidtree_bcc/filtering.py
@@ -1,10 +1,17 @@
+import ctypes
+import enum
 from collections import namedtuple
+from typing import Any
 from typing import List
 from typing import Union
 
+from pidtree_bcc.ctypes_helper import ComparableCtStructure
+from pidtree_bcc.ctypes_helper import create_comparable_array_type
 from pidtree_bcc.utils import ip_to_int
+from pidtree_bcc.utils import netmask_to_prefixlen
 
 
+NET_FILTER_MAX_PORT_RANGES = 8
 IpPortFilter = namedtuple('IpPortFilter', ('subnet', 'netmask', 'except_ports', 'include_ports'))
 
 
@@ -47,3 +54,77 @@ class NetFilter:
             ):
                 return True
         return False
+
+
+class CPortRange(ComparableCtStructure):
+    _fields_ = [
+        ('lower', ctypes.c_uint16),
+        ('upper', ctypes.c_uint16),
+    ]
+
+    @classmethod
+    def from_conf_value(cls, val: Union[int, str]) -> 'CPortRange':
+        lower, upper = (
+            map(int, val.split('-'))
+            if isinstance(val, str) and '-' in val
+            else (val, val)
+        )
+        return cls(lower=lower, upper=upper)
+
+
+class CFilterKey(ComparableCtStructure):
+    _fields_ = [
+        ('prefixlen', ctypes.c_uint32),
+        ('data', ctypes.c_uint32),
+    ]
+
+
+class CFilterValue(ComparableCtStructure):
+    range_array_t = create_comparable_array_type(NET_FILTER_MAX_PORT_RANGES, CPortRange)
+    _fields_ = [
+        ('mode', ctypes.c_int),  # this is actually an enum, which are ints in C
+        ('range_size', ctypes.c_uint8),
+        ('ranges', range_array_t),
+    ]
+
+
+class PortFilterMode(enum.IntEnum):
+    """ Reflects values used for `net_filter_mode` in utils.j2 """
+    all = 0
+    exclude = 1
+    include = 2
+
+
+def load_filters_into_map(filters: List[dict], ebpf_map: Any):
+    """ Loads network filters into a eBPF map. The map is expected to be a trie
+    with prefix as they key and net_filter_val_t as elements, according to the
+    type definitions in the `net_filter_trie_init` macro in `utils.j2`.
+
+    :param List[dict] filters: list of IP-ports filters. Format:
+                                {
+                                    'network': '127.0.0.1',
+                                    'network_mask': '255.0.0.0',
+                                    'except_ports': [123, 456], # optional
+                                    'include_ports': [789],     # optional
+                                }
+    :param Any ebpf_map: reference to eBPF table where filters should be loaded.
+    """
+    for entry in filters:
+        map_key = CFilterKey(
+            prefixlen=netmask_to_prefixlen(entry['network_mask']),
+            data=ip_to_int(entry['network']),
+        )
+        if entry.get('except_ports'):
+            mode = PortFilterMode.exclude
+            port_ranges = list(map(CPortRange.from_conf_value, entry['except_ports']))
+        elif entry.get('include_ports'):
+            mode = PortFilterMode.include
+            port_ranges = list(map(CPortRange.from_conf_value, entry['include_ports']))
+        else:
+            mode = PortFilterMode.all
+            port_ranges = []
+        ebpf_map[map_key] = CFilterValue(
+            mode=mode.value,
+            range_size=len(port_ranges),
+            ranges=CFilterValue.range_array_t(*port_ranges),
+        )

--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -6,8 +6,6 @@
 #define SESSION_CONTINUE 2
 #define SESSION_END 3
 
-{{ utils.net_filter_masks(filters, ip_to_int) }}
-
 struct udp_session_event {
     u8  type;
     u32 pid;
@@ -18,6 +16,8 @@ struct udp_session_event {
 
 BPF_PERF_OUTPUT(events);
 BPF_HASH(tracing, u64, u8);
+
+{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
 
 {{ utils.get_proto_func() }}
 
@@ -35,7 +35,7 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
     u32 daddr = sin->sin_addr.s_addr ? sin->sin_addr.s_addr : sk->sk_daddr;
     u16 dport = sin->sin_port ? sin->sin_port : sk->sk_dport;
 
-    {{ utils.net_filter_if_excluded(filters) | indent(4) }} {
+    if (is_addr_port_filtered(daddr, dport)) {
         return 0;
     }
 

--- a/pidtree_bcc/probes/udp_session.py
+++ b/pidtree_bcc/probes/udp_session.py
@@ -24,6 +24,7 @@ class UDPSessionProbe(BPFProbe):
         'includeports': [],
         'excludeports': [],
     }
+    USES_DYNAMIC_FILTERS = True
     SESSION_MAX_DURATION_DEFAULT = 120
     SESSION_START = 1
     SESSION_CONTINUE = 2

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -75,3 +75,50 @@ if (0
 {% endfor %})
 {% endif -%}
 {%- endmacro %}
+
+{% macro net_filter_trie_init(map_name, size=512, max_ports=8) -%}
+struct net_filter_key_t {
+    u32 prefixlen;
+    u32 data;
+};
+
+struct net_filter_port_range_t {
+    u16 lower;
+    u16 upper;
+};
+
+enum net_filter_mode { all = 0, exclude = 1, include = 2 };
+
+struct net_filter_val_t {
+    enum net_filter_mode mode;
+    u8 ranges_size;
+    struct net_filter_port_range_t ranges[{{ max_ports }}];
+};
+
+BPF_LPM_TRIE({{ map_name }}, struct net_filter_key_t, struct net_filter_val_t, {{ size }});
+
+// checks if the addr-port pairing is filtered
+static inline bool is_addr_port_filtered(u32 addr, u16 port) {
+    struct net_filter_key_t filter_key = { .prefixlen = 32, .data = addr };
+    struct net_filter_val_t* filter_val = {{ map_name }}.lookup(&filter_key);
+    if (filter_val != 0) {
+        struct net_filter_port_range_t curr;
+        if (filter_val->mode == all) {
+            return true;
+        }
+        for (u8 i = 0; i < {{ max_ports }}; i++) {
+            if (i >= filter_val->ranges_size) {
+                break;
+            }
+            curr = filter_val->ranges[i];
+            if (port >= curr.lower && port <= curr.upper) {
+                // range match, addr-port is filtered if in "include" mode
+                return filter_val->mode == include;
+            }
+        }
+        // no port range matched, addr-port is filtered only if in "exclude" mode
+        return filter_val->mode == exclude;
+    }
+    return false;
+}
+{%- endmacro %}

--- a/pidtree_bcc/utils.py
+++ b/pidtree_bcc/utils.py
@@ -1,6 +1,7 @@
 import functools
 import importlib
 import inspect
+import ipaddress
 import logging
 import os
 import socket
@@ -98,6 +99,15 @@ def int_to_ip(encoded_ip: int) -> str:
     :return: dot-notation IP
     """
     return socket.inet_ntoa(struct.pack('<L', encoded_ip))
+
+
+def netmask_to_prefixlen(netmask: str) -> int:
+    """ Takes an IP netmask and returns the corresponding prefix length
+
+    :param str netmask: IP netmask (e.g. 255.255.0.0)
+    :return: prefix length
+    """
+    return ipaddress.ip_network('0.0.0.0/{}'.format(netmask)).prefixlen
 
 
 def never_crash(func: Callable) -> Callable:

--- a/tests/filtering_test.py
+++ b/tests/filtering_test.py
@@ -1,5 +1,12 @@
+from unittest.mock import call
+from unittest.mock import MagicMock
+
 import pytest
 
+from pidtree_bcc.filtering import CFilterKey
+from pidtree_bcc.filtering import CFilterValue
+from pidtree_bcc.filtering import CPortRange
+from pidtree_bcc.filtering import load_filters_into_map
 from pidtree_bcc.filtering import NetFilter
 from pidtree_bcc.utils import ip_to_int
 
@@ -44,3 +51,42 @@ def test_filter_ip_except_port(net_filtering):
 def test_filter_ip_include_port(net_filtering):
     assert net_filtering.is_filtered('192.168.0.1', 123)
     assert not net_filtering.is_filtered('192.168.0.1', 80)
+
+
+def test_load_filters_into_map():
+    mock_filters = [
+        {
+            'network': '127.0.0.1',
+            'network_mask': '255.0.0.0',
+        },
+        {
+            'network': '10.0.0.1',
+            'network_mask': '255.0.0.0',
+            'except_ports': [123, 456],
+        },
+        {
+            'network': '192.168.0.1',
+            'network_mask': '255.255.0.0',
+            'include_ports': ['100-200'],
+        },
+    ]
+    res_map = MagicMock()
+    load_filters_into_map(mock_filters, res_map)
+    res_map.__setitem__.assert_has_calls([
+        call(
+            CFilterKey(prefixlen=8, data=16777343),
+            CFilterValue(mode=0, range_size=0),
+        ),
+        call(
+            CFilterKey(prefixlen=8, data=16777226),
+            CFilterValue(
+                mode=1,
+                range_size=2,
+                ranges=CFilterValue.range_array_t(CPortRange(123, 123), CPortRange(456, 456)),
+            ),
+        ),
+        call(
+            CFilterKey(prefixlen=16, data=16820416),
+            CFilterValue(mode=2, range_size=1, ranges=CFilterValue.range_array_t(CPortRange(100, 200))),
+        ),
+    ])

--- a/tests/utils_test.py
+++ b/tests/utils_test.py
@@ -3,6 +3,8 @@ import sys
 from unittest.mock import call
 from unittest.mock import patch
 
+import pytest
+
 from pidtree_bcc import utils
 
 
@@ -42,3 +44,11 @@ def test_get_network_namespace(mock_os):
     ])
     mock_os.readlink.side_effect = Exception
     assert utils.get_network_namespace() is None
+
+
+def test_netmask_to_prefixlen():
+    assert utils.netmask_to_prefixlen('0.0.0.0') == 0
+    assert utils.netmask_to_prefixlen('255.255.255.255') == 32
+    assert utils.netmask_to_prefixlen('255.0.0.0') == 8
+    with pytest.raises(ValueError):
+        utils.netmask_to_prefixlen('1.1.1.1')


### PR DESCRIPTION
Turns the network filters from a templated if-statement into a LPM trie map.
It's not very well documented how tries should be used, but digging in various places I understood that they expect a struct as key which hold a u32 prefix len, followed by an arbitrary amount of binary data, which in our case is the binary representation of IPv4 addresses.
To maintain compatibility with the current port include/exclusion settings, I made the map values old arrays with that information. It's not terribly efficient memory-wise, as there will be quite a bit of wasted allocated memory, but on average it should be a matter of just a few hundreds bytes overall.
I migrated just the UDP session probe to the new paradigm for the time being so that we can better test out the feature.