### PR TITLE
switch global port filters to BPF arrays

### DIFF
--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -12,7 +12,7 @@ struct listen_bind_t {
     u8  protocol;
 };
 
-{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
+{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, PORT_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
 
 {{ utils.get_proto_func() }}
 
@@ -32,17 +32,10 @@ static void net_listen_event(struct pt_regs *ctx)
     bpf_probe_read(&laddr, sizeof(u32), &sk->__sk_common.skc_rcv_saddr);
     bpf_probe_read(&port, sizeof(u16), &sk->__sk_common.skc_num);
 
-    if (is_addr_port_filtered(laddr, port)) {
+    if (is_addr_port_filtered(laddr, port) || is_port_globally_filtered(port)) {
         currsock.delete(&pid);
         return;
     }
-
-    {% if includeports or excludeports -%}
-    {{ utils.include_exclude_ports(includeports, excludeports, 'port') | indent(4) }} {
-        currsock.delete(&pid);
-        return;
-    }
-    {%- endif %}
 
     {% if net_namespace -%}
     if (sk->__sk_common.skc_net.net->ns.inum != {{ net_namespace }}) {

--- a/pidtree_bcc/probes/tcp_connect.j2
+++ b/pidtree_bcc/probes/tcp_connect.j2
@@ -12,7 +12,7 @@ struct connection_t {
     u16 dport;
 };
 
-{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
+{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, PORT_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
 
 int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
 {
@@ -40,23 +40,18 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
     u16 dport = 0;
     bpf_probe_read(&daddr, sizeof(daddr), &skp->__sk_common.skc_daddr);
     bpf_probe_read(&dport, sizeof(dport), &skp->__sk_common.skc_dport);
+    dport = ntohs(dport);
 
-    if (is_addr_port_filtered(daddr, ntohs(dport))) {
-        return 0;
-    }
-
-    {% if includeports or excludeports -%}
-    {{ utils.include_exclude_ports(includeports, excludeports, 'ntohs(dport)') | indent(4) }} {
+    if (is_addr_port_filtered(daddr, dport) || is_port_globally_filtered(dport)) {
         currsock.delete(&pid);
         return 0;
     }
-    {%- endif %}
 
     bpf_probe_read(&saddr, sizeof(saddr), &skp->__sk_common.skc_rcv_saddr);
 
     struct connection_t connection = {};
     connection.pid = pid;
-    connection.dport = ntohs(dport);
+    connection.dport = dport;
     connection.daddr = daddr;
     connection.saddr = saddr;
 

--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -17,7 +17,7 @@ struct udp_session_event {
 BPF_PERF_OUTPUT(events);
 BPF_HASH(tracing, u64, u8);
 
-{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
+{{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, PORT_FILTER_MAP_NAME, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
 
 {{ utils.get_proto_func() }}
 
@@ -34,16 +34,11 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
     struct sockaddr_in* sin = msg->msg_name;
     u32 daddr = sin->sin_addr.s_addr ? sin->sin_addr.s_addr : sk->sk_daddr;
     u16 dport = sin->sin_port ? sin->sin_port : sk->sk_dport;
+    dport = ntohs(dport);
 
-    if (is_addr_port_filtered(daddr, ntohs(dport))) {
+    if (is_addr_port_filtered(daddr, dport) || is_port_globally_filtered(dport)) {
         return 0;
     }
-
-    {% if includeports or excludeports -%}
-    {{ utils.include_exclude_ports(includeports, excludeports, 'ntohs(dport)') | indent(4) }} {
-        return 0;
-    }
-    {%- endif %}
 
     // Check if we are already tracing this session
     u64 sock_pointer = (u64) sk;
@@ -56,7 +51,6 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
     session.sock_pointer = sock_pointer;
     bpf_probe_read(&session.daddr, sizeof(u32), &daddr);
     bpf_probe_read(&session.dport, sizeof(u16), &dport);
-    session.dport = ntohs(session.dport);
     events.perf_submit(ctx, &session, sizeof(session));
     if(trace_flag == SESSION_START) {
         // We don't care about the actual value in the map

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -76,7 +76,7 @@ if (0
 {% endif -%}
 {%- endmacro %}
 
-{% macro net_filter_trie_init(map_name, size=512, max_ports=8) -%}
+{% macro net_filter_trie_init(prefix_filter_var_name, port_filter_var_name, size=512, max_ports=8) -%}
 struct net_filter_key_t {
     u32 prefixlen;
     u32 data;
@@ -95,14 +95,16 @@ struct net_filter_val_t {
     struct net_filter_port_range_t ranges[{{ max_ports }}];
 };
 
-BPF_LPM_TRIE({{ map_name }}, struct net_filter_key_t, struct net_filter_val_t, {{ size }});
+BPF_LPM_TRIE({{ prefix_filter_var_name }}, struct net_filter_key_t, struct net_filter_val_t, {{ size }});
+
+BPF_ARRAY({{ port_filter_var_name }}, u8, 65536);  // element 0 stores mode flag (exclude / include)
 
 // checks if the addr-port pairing is filtered
 // `addr` is expected in 32 bit integer format
 // `port` is expected in host byte order
 static inline bool is_addr_port_filtered(u32 addr, u16 port) {
     struct net_filter_key_t filter_key = { .prefixlen = 32, .data = addr };
-    struct net_filter_val_t* filter_val = {{ map_name }}.lookup(&filter_key);
+    struct net_filter_val_t* filter_val = {{ prefix_filter_var_name }}.lookup(&filter_key);
     if (filter_val != 0) {
         struct net_filter_port_range_t curr;
         if (filter_val->mode == all) {
@@ -122,5 +124,17 @@ static inline bool is_addr_port_filtered(u32 addr, u16 port) {
         return filter_val->mode == exclude;
     }
     return false;
+}
+
+// check if port is filtered globally in the probe configuration
+// `port` is expected in host byte order
+static inline bool is_port_globally_filtered(u16 port) {
+    int zero = 0, intport = (int)port;  // required cause array keys must be ints
+    u8* mode = {{port_filter_var_name}}.lookup(&zero);
+    u8* match = {{port_filter_var_name}}.lookup(&intport);
+    return (
+        (mode && match)  // we need to check the map pointers to make the compiler happy
+        && ((*mode == exclude && *match) || (*mode == include && !*match))
+    );
 }
 {%- endmacro %}

--- a/tests/filtering_test.py
+++ b/tests/filtering_test.py
@@ -7,7 +7,10 @@ from pidtree_bcc.filtering import CFilterKey
 from pidtree_bcc.filtering import CFilterValue
 from pidtree_bcc.filtering import CPortRange
 from pidtree_bcc.filtering import load_filters_into_map
+from pidtree_bcc.filtering import load_port_filters_into_map
 from pidtree_bcc.filtering import NetFilter
+from pidtree_bcc.filtering import port_range_mapper
+from pidtree_bcc.filtering import PortFilterMode
 from pidtree_bcc.utils import ip_to_int
 
 
@@ -90,3 +93,26 @@ def test_load_filters_into_map():
             CFilterValue(mode=2, range_size=1, ranges=CFilterValue.range_array_t(CPortRange(100, 200))),
         ),
     ])
+
+
+@pytest.mark.parametrize(
+    'filter_input,mode,expected',
+    [
+        ((22, 80, 443), PortFilterMode.include, {0: 2, 22: 1, 80: 1, 443: 1}),
+        (('10-20',), PortFilterMode.exclude, {0: 1, **{i: 1 for i in range(10, 21)}}),
+        ((1, '2-9', 10), PortFilterMode.exclude, {i: 1 for i in range(11)}),
+    ],
+)
+def test_load_port_filters_into_map(filter_input, mode, expected):
+    res_map = MagicMock()
+    load_port_filters_into_map(filter_input, mode, res_map)
+    assert expected == {
+        call_args[0][0].value: call_args[0][1].value
+        for call_args in res_map.__setitem__.call_args_list
+    }
+
+
+def test_port_range_mapper():
+    assert list(port_range_mapper('22-80')) == list(range(22, 81))
+    assert list(port_range_mapper('0-10')) == list(range(1, 11))
+    assert list(port_range_mapper('100-100000000')) == list(range(100, 65535))


### PR DESCRIPTION
Moves the global probe settings `includeports` and `excludeports` to use a 2^16 BPF array to store whether a port is included/excluded. This wastes a bit of memory, but it's definitely the most straightforward implementation which doesn't require thinking about some weird way to store the data, or restricts the number of filters which can be declared in configuration.