### PR TITLE
Ubuntu jammy actual support

### DIFF
--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -1,4 +1,5 @@
 {%- import 'utils.j2' as utils -%}
+{{ utils.patch_buggy_headers(PATCH_BUGGY_HEADERS) }}
 #include <net/sock.h>
 #include <bcc/proto.h>
 

--- a/pidtree_bcc/probes/tcp_connect.j2
+++ b/pidtree_bcc/probes/tcp_connect.j2
@@ -1,4 +1,5 @@
 {%- import 'utils.j2' as utils -%}
+{{ utils.patch_buggy_headers(PATCH_BUGGY_HEADERS) }}
 #include <net/sock.h>
 #include <bcc/proto.h>
 

--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -1,4 +1,5 @@
 {%- import 'utils.j2' as utils -%}
+{{ utils.patch_buggy_headers(PATCH_BUGGY_HEADERS) }}
 #include <net/sock.h>
 #include <bcc/proto.h>
 

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -138,3 +138,19 @@ static inline bool is_port_globally_filtered(u16 port) {
     );
 }
 {%- endmacro %}
+
+{% macro patch_buggy_headers(do_patch=False) -%}
+{% if do_patch -%}
+// This is just a work around to some issues with latest kernels:
+// - https://github.com/iovisor/bcc/issues/3366
+// - https://github.com/iovisor/bcc/issues/3993
+struct bpf_timer {
+    __u64 :64;
+    __u64 :64;
+};
+enum {
+    BPF_F_BROADCAST       = (1ULL << 3),
+    BPF_F_EXCLUDE_INGRESS = (1ULL << 4),
+};
+{%- endif %}
+{%- endmacro %}

--- a/pidtree_bcc/utils.py
+++ b/pidtree_bcc/utils.py
@@ -31,7 +31,7 @@ def crawl_process_tree(pid: int) -> List[dict]:
         result.append(
             {
                 'pid': proc.pid,
-                'cmdline': ' '.join(proc.cmdline()),
+                'cmdline': ' '.join(proc.cmdline()).strip(),
                 'username': proc.username(),
             },
         )


### PR DESCRIPTION
Most of the issues seem to be related to forward definition of things in kernel headers, so I decided to give a try to re-define the things which were causing trouble, and it seemed to have work. This is potentially a bit of a timebomb waiting to explode if anything changes in the kernel, but that's pretty much true for the entire tool implementation, so happy to live with the ticking.

While figuring this out, I noticed that we were wasteful with trailing whitespace on command lines, so `.strip()`.