### PR TITLE
patch BPF_PSEUDO_FUNC define

### DIFF
--- a/pidtree_bcc/probes/__init__.py
+++ b/pidtree_bcc/probes/__init__.py
@@ -12,6 +12,7 @@ from threading import Thread
 from typing import Any
 from typing import Mapping
 
+from bcc import __version__ as bccversion
 from bcc import BPF
 from jinja2 import Environment
 from jinja2 import FileSystemLoader
@@ -142,7 +143,8 @@ class BPFProbe:
         """
         kernel_version = platform.uname().release
         kmajor, kminor = map(int, kernel_version.split('.', 2)[:2])
-        return (kmajor == 5 and kminor >= 15) or kmajor > 5
+        _, bccminor, _ = map(int, bccversion.split('.'))
+        return bccminor < 23 and ((kmajor == 5 and kminor >= 15) or kmajor > 5)
 
     def _process_events(self, cpu: Any, data: Any, size: Any, from_bpf: bool = True):
         """ BPF event callback

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -152,5 +152,7 @@ enum {
     BPF_F_BROADCAST       = (1ULL << 3),
     BPF_F_EXCLUDE_INGRESS = (1ULL << 4),
 };
+// Missing header value in bcc <0.19.0 (Ubuntu Jammy comes with 0.18.0)
+#define BPF_PSEUDO_FUNC 4
 {%- endif %}
 {%- endmacro %}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,4 +4,5 @@ from unittest.mock import MagicMock
 
 # Globally mock bcc module
 bcc = MagicMock()
+bcc.__version__ = '0.18.0'
 sys.modules.setdefault('bcc', bcc)


### PR DESCRIPTION
The constant is defined in [this header](https://elixir.bootlin.com/linux/v5.15.78/source/tools/include/uapi/linux/bpf.h), which libbcc [actually vendors](https://github.com/iovisor/bcc/blob/298cc9e971469626b828d54b955e7026f76a0008/src/cc/compat/linux/virtual_bpf.h#L1200), except that this `#define` starts appearing in version `0.19.0` of libbcc and Ubuntu Jammy ships with `libbpfcc 0.18.0+ds-2` (and kernel 5.15).

It's a solution which makes me terribly unhappy, but at least it works, while I didn't manage to get source-built version of BCC not to crash.