### PR TITLE
fix shutdown behaviour of remote config fetcher

### DIFF
--- a/pidtree_bcc/main.py
+++ b/pidtree_bcc/main.py
@@ -22,6 +22,7 @@ from pidtree_bcc.probes import load_probes
 from pidtree_bcc.utils import self_restart
 from pidtree_bcc.utils import smart_open
 from pidtree_bcc.utils import StopFlagWrapper
+from pidtree_bcc.yaml_loader import FileIncludeLoader
 
 
 EXIT_CODE = 0
@@ -203,6 +204,7 @@ def main(args: argparse.Namespace):
             out.flush()
     except RestartSignal:
         stop_wrapper.stop()
+        FileIncludeLoader.cleanup()
         raise
     except Exception as e:
         # Terminate everything if something goes wrong

--- a/tests/yaml_loader_test.py
+++ b/tests/yaml_loader_test.py
@@ -37,6 +37,7 @@ def test_file_include_remote(mock_request, mock_tempfile, tmp_path):
         with open('tests/fixtures/remote_config.yaml') as f:
             data = yaml.load(f, Loader=loader)
     stop_flag.stop()
+    FileIncludeLoader.cleanup()
     assert data == {
         'foo': [1, {'a': 2, 'b': 3}, 4],
         'bar': {'fizz': 'buzz'},
@@ -47,3 +48,5 @@ def test_file_include_remote(mock_request, mock_tempfile, tmp_path):
     mock_request.urlopen.assert_called_once_with(
         'https://raw.githubusercontent.com/Yelp/pidtree-bcc/master/tests/fixtures/child_config.yaml',
     )
+    assert not FileIncludeLoader.remote_fetch_workload
+    assert not FileIncludeLoader.remote_fetcher.is_alive()


### PR DESCRIPTION
Configuration fetching is working fine, but on self-restart the background thread would not be terminating fast enough by itself (understandably, considering it has a 1h wait timeout) so when the class would get loaded again it would come with some "virtually dead" thread, preventing to load the new config again.

I also switched the `include_remote` to be a class method, as I was definitely abusing the "class properties are also instance properties" aspect of python. It's a bit cleaner this way.