### PR TITLE
support selecting events from specific containers

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -23,6 +23,8 @@ _net_filters: &net_filters
 # Some configuration fields supported by all probes:
 #   filters: list of network filters (see above for schema); they act on the destination
 #            address for tcp_connect and udp_session, local listening address for net_listen
+#   container_labels: list of label filters to only capture events generated from processes in containers
+#   container_poll_interval: how often to poll for running containers (in seconds)
 #   excludeports: list of ports to be filtered out (cannot be used with includeports)
 #   includeports: list of ports for which events will be logged (filters out all the others) (cannot be used with excludeports)
 #   plugins: map of plugins to enable for the probe (check README for more details)
@@ -31,6 +33,8 @@ udp_session:
   filters: *net_filters
 tcp_connect:
   filters: *net_filters
+  container_labels:
+    - key=value
   plugins:
     sourceipmap:
       enabled: True

--- a/pidtree_bcc/config.py
+++ b/pidtree_bcc/config.py
@@ -24,7 +24,7 @@ from pidtree_bcc.yaml_loader import FileIncludeLoader
 
 HOTSWAP_CALLBACK_NAMESPACE = get_namespace('__change_callbacks')
 LOADED_CONFIG_FILES_NAMESPACE = get_namespace('__loaded_configs')
-HOT_SWAPPABLE_SETTINGS = ('filters', 'excludeports', 'includeports')
+HOT_SWAPPABLE_SETTINGS = ('filters', 'excludeports', 'includeports', 'container_labels')
 NON_PROBE_NAMESPACES = (DEFAULT_NAMESPACE, HOTSWAP_CALLBACK_NAMESPACE.name, LOADED_CONFIG_FILES_NAMESPACE.name)
 
 

--- a/pidtree_bcc/containers.py
+++ b/pidtree_bcc/containers.py
@@ -1,0 +1,82 @@
+import logging
+import os
+import subprocess
+from functools import lru_cache
+from itertools import chain
+from typing import List
+from typing import Set
+
+
+@lru_cache(maxsize=1)
+def detect_containerizer_client() -> str:
+    """ Detect whether the system is using Docker or Containerd.
+    Since containerd does not have a proper python API implementation, we rely on
+    CLI tools to query container information in both cases.
+    This method is very opinionated towards detecting Containerd usage in Kubernetes,
+    so in most cases it will fall back to standard Docker.
+
+    :return: CLI tool to query containerizer
+    """
+    return 'nerdctl' if os.path.exists('/var/run/containerd/io.containerd.runtime.v2.task/k8s.io') else 'docker'
+
+
+def list_containers(filter_labels: List[str] = None) -> List[str]:
+    """ List running containers matching filter
+
+    :param List[str] filter_labels: list of label values, either `<label_name>` or `<label_name>=<label_value>`
+    :return: yields container hash IDs
+    """
+    filter_args = chain.from_iterable(('--filter', f'label={label}') for label in (filter_labels or []))
+    try:
+        output = subprocess.check_output(
+            (
+                detect_containerizer_client(), 'ps',
+                '--no-trunc', '--quiet', *filter_args,
+            ), encoding='utf8',
+        )
+        return output.splitlines()
+    except Exception as e:
+        logging.error(f'Issue listing running containers: {e}')
+    return []
+
+
+@lru_cache(maxsize=2048)
+def get_container_mntns_id(sha: str) -> int:
+    """ Get mount namespace ID for a container
+
+    :param str sha: container hash ID
+    :return: mount namespace ID
+    """
+    try:
+        output = subprocess.check_output(
+            (
+                detect_containerizer_client(), 'inspect',
+                '-f', r'{{.State.Pid}}', sha,
+            ), encoding='utf8',
+        )
+        pid = int(output.splitlines()[0])
+    except Exception as e:
+        logging.error(f'Issue inspecting container {sha}: {e}')
+        return -1
+    try:
+        return os.stat(f'/proc/{pid}/ns/mnt').st_ino
+    except Exception as e:
+        logging.error(f'Issue reading mntns ID for {pid}: {e}')
+    return -1
+
+
+def list_container_mnt_namespaces(filter_labels: List[str] = None) -> Set[int]:
+    """ Get collection of mount namespace IDs for running containers matching label filters
+
+    :param List[str] filter_labels: list of label values, either `<label_name>` or `<label_name>=<label_value>`
+    :return: set of mount namespace IDs
+    """
+    return {
+        mntns_id
+        for mntns_id in (
+            get_container_mntns_id(container_id)
+            for container_id in list_containers(filter_labels)
+            if container_id
+        )
+        if mntns_id > 0
+    }

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -17,6 +17,10 @@ struct listen_bind_t {
 
 {{ utils.get_proto_func() }}
 
+{% if container_labels %}
+{{ utils.mntns_filter_init(MNTNS_FILTER_MAP_NAME) }}
+{% endif %}
+
 static void net_listen_event(struct pt_regs *ctx)
 {
     u32 pid = bpf_get_current_pid_tgid();
@@ -61,6 +65,11 @@ int kprobe__inet_bind(
     const struct sockaddr *addr,
     int addrlen)
 {
+    {% if container_labels -%}
+    if (!is_mntns_included()) {
+        return 0;
+    }
+    {% endif -%}
     {% if exclude_random_bind -%}
     struct sockaddr_in* inet_addr = (struct sockaddr_in*)addr;
     if (inet_addr->sin_port == 0) {
@@ -86,6 +95,11 @@ int kretprobe__inet_bind(struct pt_regs *ctx)
 {% if 'tcp' in protocols -%}
 int kprobe__inet_listen(struct pt_regs *ctx, struct socket *sock, int backlog)
 {
+    {% if container_labels -%}
+    if (!is_mntns_included()) {
+        return 0;
+    }
+    {% endif -%}
     struct sock* sk = sock->sk;
     if (sk->__sk_common.skc_family == AF_INET) {
         u32 pid = bpf_get_current_pid_tgid();

--- a/pidtree_bcc/probes/net_listen.py
+++ b/pidtree_bcc/probes/net_listen.py
@@ -32,6 +32,7 @@ class NetListenProbe(BPFProbe):
         'ip_to_int': ip_to_int,
         'protocols': ['tcp'],
         'filters': [],
+        'container_labels': [],
         'excludeports': [],
         'includeports': [],
         'snapshot_periodicity': False,

--- a/pidtree_bcc/probes/tcp_connect.j2
+++ b/pidtree_bcc/probes/tcp_connect.j2
@@ -15,8 +15,17 @@ struct connection_t {
 
 {{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, PORT_FILTER_MAP_NAME, size=NET_FILTER_MAP_SIZE, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
 
+{% if container_labels %}
+{{ utils.mntns_filter_init(MNTNS_FILTER_MAP_NAME) }}
+{% endif %}
+
 int kprobe__tcp_v4_connect(struct pt_regs *ctx, struct sock *sk)
 {
+    {% if container_labels -%}
+    if (!is_mntns_included()) {
+        return 0;
+    }
+    {% endif -%}
     u32 pid = bpf_get_current_pid_tgid();
     currsock.update(&pid, &sk);
     return 0;

--- a/pidtree_bcc/probes/tcp_connect.py
+++ b/pidtree_bcc/probes/tcp_connect.py
@@ -12,6 +12,7 @@ class TCPConnectProbe(BPFProbe):
     CONFIG_DEFAULTS = {
         'ip_to_int': ip_to_int,
         'filters': [],
+        'container_labels': [],
         'includeports': [],
         'excludeports': [],
     }

--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -22,6 +22,10 @@ BPF_HASH(tracing, u64, u8);
 
 {{ utils.get_proto_func() }}
 
+{% if container_labels %}
+{{ utils.mntns_filter_init(MNTNS_FILTER_MAP_NAME) }}
+{% endif %}
+
 // We probe only the entrypoint as looking at return codes doesn't have much value
 // since UDP does not do any checks for successfull communications. The only errors
 // which may arise from this function would be due to the kernel running out of memory,
@@ -29,6 +33,12 @@ BPF_HASH(tracing, u64, u8);
 int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg, size_t size)
 {
     if(sk->__sk_common.skc_family != AF_INET) return 0;
+
+    {% if container_labels -%}
+    if (!is_mntns_included()) {
+        return 0;
+    }
+    {% endif -%}
 
     // Destination info will either be embedded in the socket if `connect`
     // was called or specified in the message

--- a/pidtree_bcc/probes/udp_session.py
+++ b/pidtree_bcc/probes/udp_session.py
@@ -20,6 +20,7 @@ class UDPSessionProbe(BPFProbe):
     CONFIG_DEFAULTS = {
         'ip_to_int': ip_to_int,
         'filters': [],
+        'container_labels': [],
         'includeports': [],
         'excludeports': [],
     }

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -156,3 +156,30 @@ enum {
 #define BPF_PSEUDO_FUNC 4
 {%- endif %}
 {%- endmacro %}
+
+{% macro mntns_filter_init(mntns_filter_map_name, size=512) -%}
+
+/* Original source: https://github.com/iovisor/bcc/blob/master/tools/mountsnoop.py#L32-L52
+ * `struct mnt_namespace` is defined in fs/mount.h, which is private
+ * to the VFS and not installed in any kernel-devel packages. So, let's
+ * duplicate the important part of the definition. There are actually
+ * more members in the real struct, but we don't need them, and they're
+ * more likely to change.
+ */
+struct mnt_namespace {
+    // This field was removed in https://github.com/torvalds/linux/commit/1a7b8969e664d6af328f00fe6eb7aabd61a71d13
+    #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 11, 0)
+    atomic_t count;
+    #endif
+    struct ns_common ns;
+};
+
+BPF_HASH({{ mntns_filter_map_name }}, u64, bool, {{ size }});
+
+static inline bool is_mntns_included() {
+    struct task_struct *task;
+    task = (struct task_struct *)bpf_get_current_task();
+    u64 mntns_id = task->nsproxy->mnt_ns->ns.inum;
+    return {{ mntns_filter_map_name }}.lookup(&mntns_id) != NULL;
+}
+{%- endmacro %}

--- a/tests/containers_test.py
+++ b/tests/containers_test.py
@@ -1,0 +1,36 @@
+import subprocess
+from unittest.mock import call
+from unittest.mock import MagicMock
+from unittest.mock import patch
+
+from pidtree_bcc.containers import list_container_mnt_namespaces
+
+
+@patch('pidtree_bcc.containers.os')
+@patch('pidtree_bcc.containers.subprocess')
+def test_list_container_mnt_namespaces(mock_subprocess, mock_os):
+    mock_subprocess.check_output.side_effect = [
+        'aaaabbbbcccc\nddddeeeeffff\naaaacccceeee\nbbbbddddffff',
+        '123',
+        subprocess.CalledProcessError,
+        '456',
+        '789',
+    ]
+    mock_os.path.exists.return_value = False
+    mock_os.stat.side_effect = [
+        MagicMock(st_ino=111),
+        MagicMock(st_ino=222),
+        IOError,
+    ]
+    assert list_container_mnt_namespaces(['a=b']) == {111, 222}
+    mock_subprocess.check_output.assert_has_calls([
+        call(('docker', 'ps', '--no-trunc', '--quiet', '--filter', 'label=a=b'), encoding='utf8'),
+        call(('docker', 'inspect', '-f', r'{{.State.Pid}}', 'aaaabbbbcccc'), encoding='utf8'),
+        call(('docker', 'inspect', '-f', r'{{.State.Pid}}', 'ddddeeeeffff'), encoding='utf8'),
+        call(('docker', 'inspect', '-f', r'{{.State.Pid}}', 'aaaacccceeee'), encoding='utf8'),
+    ])
+    mock_os.stat.assert_has_calls([
+        call('/proc/123/ns/mnt'),
+        call('/proc/456/ns/mnt'),
+        call('/proc/789/ns/mnt'),
+    ])

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ skip_missing_interpreters = true
 setenv =
     PIP_PREFER_BINARY=true
 deps =
+    setuptools<70.0.0
     -rrequirements.txt
     -rrequirements-dev.txt
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py38,py310
+envlist = py38,py310
 skip_missing_interpreters = true
 
 [testenv]
@@ -24,6 +24,5 @@ max-line-length = 120
 
 [gh-actions]
 python =
-    3.6: py36
     3.8: py38
     3.10: py310


### PR DESCRIPTION
This change adds a configuration option compatible with all existing probes which allows selecting running containers on the host via a list of label filters and only track networking events for those.
That's achieved via matching the mount namespace for each process with the one to which the main processes of the containers belong. It's the same kind of strategy adopted by many scripts in [bcc-tools](https://github.com/iovisor/bcc/blob/master/src/python/bcc/containers.py).