### PR TITLE
improve handling of container tracing

### DIFF
--- a/example_config.yml
+++ b/example_config.yml
@@ -23,8 +23,9 @@ _net_filters: &net_filters
 # Some configuration fields supported by all probes:
 #   filters: list of network filters (see above for schema); they act on the destination
 #            address for tcp_connect and udp_session, local listening address for net_listen
-#   container_labels: list of label filters to only capture events generated from processes in containers
-#   container_poll_interval: how often to poll for running containers (in seconds)
+#   container_labels: list of label glob patterns to only capture events generated from processes in containers;
+#                     each entry is in the format `label1=patter1,label2=pattern2,...` where commas are treated like
+#                     and AND, while different entries are OR'ed to each other
 #   excludeports: list of ports to be filtered out (cannot be used with includeports)
 #   includeports: list of ports for which events will be logged (filters out all the others) (cannot be used with excludeports)
 #   plugins: map of plugins to enable for the probe (check README for more details)

--- a/pidtree_bcc/containers.py
+++ b/pidtree_bcc/containers.py
@@ -1,10 +1,40 @@
+import enum
+import fnmatch
+import json
 import logging
 import os
+import shlex
 import subprocess
+import time
 from functools import lru_cache
 from itertools import chain
+from typing import Callable
+from typing import Generator
+from typing import Iterable
 from typing import List
+from typing import NamedTuple
 from typing import Set
+from typing import Tuple
+
+
+class ContainerEventType(enum.Enum):
+    start = 'start'
+    stop = 'stop'
+
+
+class ContainerEvent(NamedTuple):
+    event_type: ContainerEventType
+    container_id: str
+
+    def __bool__(self) -> bool:
+        return bool(self.container_id)
+
+
+class MountNSInfo(NamedTuple):
+    container_id: str
+    container_name: str
+    ns_id: int
+    event_type: ContainerEventType = ContainerEventType.start
 
 
 @lru_cache(maxsize=1)
@@ -40,43 +70,177 @@ def list_containers(filter_labels: List[str] = None) -> List[str]:
     return []
 
 
+def extract_container_name(inspect_data: dict) -> str:
+    """ Extracts name from container information, falling back to labels if needed.
+    This is needed because the "Name" field is basically always empty for containerd.
+
+    :param dict inspect_data: container information
+    :return: container name
+    """
+    name = inspect_data.get('Name', '').lstrip('/')
+    return (
+        name
+        if name
+        else inspect_data.get('Config', {}).get('Labels', {}).get('io.kubernetes.pod.name', '')
+    )
+
+
 @lru_cache(maxsize=2048)
-def get_container_mntns_id(sha: str) -> int:
+def inspect_container(sha: str) -> dict:
+    """ Inspect container
+
+    :param str sha: container hash ID
+    :return: inspect data
+    """
+    output = subprocess.check_output(
+        (detect_containerizer_client(), 'inspect', sha),
+        encoding='utf8',
+    )
+    return json.loads(output)[0]
+
+
+@lru_cache(maxsize=20000)
+def get_container_mntns_id(sha: str, second_try: bool = False) -> int:
     """ Get mount namespace ID for a container
 
     :param str sha: container hash ID
     :return: mount namespace ID
     """
     try:
-        output = subprocess.check_output(
-            (
-                detect_containerizer_client(), 'inspect',
-                '-f', r'{{.State.Pid}}', sha,
-            ), encoding='utf8',
-        )
-        pid = int(output.splitlines()[0])
+        inspect_data = inspect_container(sha)
+        main_pid = inspect_data['State']['Pid']
+        if main_pid == 0 and not second_try:
+            # when detecting containers from the events stream, we may be
+            # "too fast" and there is no process associated to the container yet
+            time.sleep(0.5)
+            return get_container_mntns_id(sha, second_try=True)
     except Exception as e:
         logging.error(f'Issue inspecting container {sha}: {e}')
         return -1
     try:
-        return os.stat(f'/proc/{pid}/ns/mnt').st_ino
+        return os.stat(f'/proc/{main_pid}/ns/mnt').st_ino
     except Exception as e:
-        logging.error(f'Issue reading mntns ID for {pid}: {e}')
+        logging.error(f'Issue reading mntns ID for {main_pid}: {e}')
     return -1
 
 
-def list_container_mnt_namespaces(filter_labels: List[str] = None) -> Set[int]:
+def filter_containers_with_label_patterns(
+    container_ids: Iterable[str],
+    patterns: Iterable[str],
+) -> List[Tuple[str, str]]:
+    """ Given a list of container IDs, find the ones with labels matching any of the patterns
+
+    :param Iterable[str] container_ids: collection of container IDs
+    :param Iterable[str] patterns: collection of label patterns, with entries in the format `<label_name>=<pattern>,...`
+    :return: filtered list of container IDs
+    """
+    result = []
+    unpacked_patterns = [
+        [pattern.split('=', 1) for pattern in pattern_set.split(',')]
+        for pattern_set in patterns
+    ]
+    for container_id in container_ids:
+        try:
+            container_info = inspect_container(container_id)
+            labels = container_info.get('Config', {}).get('Labels', {})
+            if labels and any(
+                all(
+                    label_key in labels
+                    and fnmatch.fnmatch(labels[label_key], pattern)
+                    for label_key, pattern in pattern_set
+                )
+                for pattern_set in unpacked_patterns
+            ):
+                result.append((container_id, extract_container_name(container_info)))
+        except Exception as e:
+            logging.error(f'Issue inspecting container {container_id}: {e}')
+    return result
+
+
+def list_container_mnt_namespaces(
+    patterns: Iterable[str] = None,
+    generator: Callable[[], List[str]] = list_containers,
+) -> Set[MountNSInfo]:
     """ Get collection of mount namespace IDs for running containers matching label filters
 
-    :param List[str] filter_labels: list of label values, either `<label_name>` or `<label_name>=<label_value>`
-    :return: set of mount namespace IDs
+    :param Iterable[str] filter_labels: list of label values, `<label_name>=<pattern>,...`
+    :param Callable[[], List[str]] generator: method to call to generate container ID list
+    :return: set of mount namespace info
     """
+    patterns = patterns if patterns else []
     return {
-        mntns_id
-        for mntns_id in (
-            get_container_mntns_id(container_id)
-            for container_id in list_containers(filter_labels)
+        mntns_info
+        for mntns_info in (
+            MountNSInfo(container_id, name, get_container_mntns_id(container_id))
+            for container_id, name in filter_containers_with_label_patterns(generator(), patterns)
             if container_id
         )
-        if mntns_id > 0
+        if mntns_info.ns_id > 0
     }
+
+
+def monitor_container_mnt_namespaces(patterns: Iterable[str] = None) -> Generator[MountNSInfo, None, None]:
+    """ Listens to containerizer events for new containers being created, and grab their namespace info
+
+    :param Iterable[str] filter_labels: list of label values, `<label_name>=<pattern>,...`
+    :return: set of mount namespace info
+    """
+    for event in monitor_container_events():
+        if event.event_type == ContainerEventType.start:
+            yield from list_container_mnt_namespaces(patterns, lambda: [event.container_id])
+        else:
+            yield MountNSInfo(event.container_id, '', 0, event.event_type)
+
+
+def _tail_subprocess_json(cmd: str, shell: bool = False) -> Generator[dict, None, None]:
+    """ Run command and tail output line by line, parsing it as JSON
+
+    :param Iterable[str] cmd: command to run
+    :return: yield dicts, stops on errors
+    """
+    try:
+        with subprocess.Popen(
+            args=cmd if shell else shlex.split(cmd),
+            stdout=subprocess.PIPE,
+            encoding='utf-8',
+            shell=shell,
+        ) as proc:
+            for line in proc.stdout:
+                if not line.strip():
+                    continue
+                yield json.loads(line)
+    except Exception as e:
+        logging.error(f'Error while running {cmd}: {e}')
+
+
+def monitor_container_events() -> Generator[ContainerEvent, None, None]:
+    """ Listens to containerizer events for new containers being created
+
+    :return: yields container IDs
+    """
+    client_cli = detect_containerizer_client()
+    if client_cli == 'docker':
+        use_shell = False
+        event_filters = '--filter type=container --filter event=start --filter event=die'
+
+        def event_extractor(event): return ContainerEvent(
+            ContainerEventType.start if event.get('status', '') == 'start' else ContainerEventType.stop,
+            event.get('id', ''),
+        )
+    else:
+        use_shell = True
+        event_filters = "| grep -E '/tasks/(start|delete)'"
+
+        def event_extractor(event): return ContainerEvent(
+            ContainerEventType.start if event.get('Topic', '').endswith('start') else ContainerEventType.stop,
+            event.get('ID', ''),
+        )
+
+    cmd = f"{client_cli} events --format '{{{{json .}}}}' {event_filters}"
+    while True:
+        event_gen = _tail_subprocess_json(cmd, use_shell)
+        for event in event_gen:
+            res = event_extractor(event)
+            if not res:
+                continue
+            yield res

--- a/pidtree_bcc/probes/net_listen.j2
+++ b/pidtree_bcc/probes/net_listen.j2
@@ -11,6 +11,9 @@ struct listen_bind_t {
     u32 laddr;
     u16 port;
     u8  protocol;
+{%- if container_labels %}
+    u64 mntns_id;
+{% endif -%}
 };
 
 {{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, PORT_FILTER_MAP_NAME, size=NET_FILTER_MAP_SIZE, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
@@ -54,6 +57,9 @@ static void net_listen_event(struct pt_regs *ctx)
     listen.port = port;
     listen.laddr = laddr;
     listen.protocol = get_socket_protocol(sk);
+    {% if container_labels -%}
+    listen.mntns_id = get_mntns_id();
+    {% endif -%}
     events.perf_submit(ctx, &listen, sizeof(listen));
     currsock.delete(&pid);
 }

--- a/pidtree_bcc/probes/net_listen.py
+++ b/pidtree_bcc/probes/net_listen.py
@@ -89,14 +89,17 @@ class NetListenProbe(BPFProbe):
         except Exception:
             error = traceback.format_exc()
             proctree = []
-        return {
-            'pid': event.pid,
-            'port': event.port,
-            'proctree': proctree,
-            'laddr': int_to_ip(event.laddr),
-            'protocol': self.PROTO_MAP.get(event.protocol, 'unknown'),
-            'error': error,
-        }
+        return self.enrich_container_name(
+            event,
+            {
+                'pid': event.pid,
+                'port': event.port,
+                'proctree': proctree,
+                'laddr': int_to_ip(event.laddr),
+                'protocol': self.PROTO_MAP.get(event.protocol, 'unknown'),
+                'error': error,
+            },
+        )
 
     def _filter_net_namespace(self, pid: int) -> bool:
         """ Check if network namespace for process is filtered

--- a/pidtree_bcc/probes/tcp_connect.j2
+++ b/pidtree_bcc/probes/tcp_connect.j2
@@ -11,6 +11,9 @@ struct connection_t {
     u32 daddr;
     u32 saddr;
     u16 dport;
+{%- if container_labels %}
+    u64 mntns_id;
+{% endif -%}
 };
 
 {{ utils.net_filter_trie_init(NET_FILTER_MAP_NAME, PORT_FILTER_MAP_NAME, size=NET_FILTER_MAP_SIZE, max_ports=NET_FILTER_MAX_PORT_RANGES) }}
@@ -64,6 +67,9 @@ int kretprobe__tcp_v4_connect(struct pt_regs *ctx)
     connection.dport = dport;
     connection.daddr = daddr;
     connection.saddr = saddr;
+    {% if container_labels -%}
+    connection.mntns_id = get_mntns_id();
+    {% endif -%}
 
     events.perf_submit(ctx, &connection, sizeof(connection));
 

--- a/pidtree_bcc/probes/tcp_connect.py
+++ b/pidtree_bcc/probes/tcp_connect.py
@@ -30,15 +30,18 @@ class TCPConnectProbe(BPFProbe):
         except Exception:
             error = traceback.format_exc()
             proctree = []
-        return {
-            'pid': event.pid,
-            'proctree': proctree,
-            # We're turning a little-endian insigned long ('<L')
-            # representation of the destination address sent from the
-            # kernel to a python `int` and then turning that into a string
-            # representation of an IP address:
-            'daddr': int_to_ip(event.daddr),
-            'saddr': int_to_ip(event.saddr),
-            'port': event.dport,
-            'error': error,
-        }
+        return self.enrich_container_name(
+            event,
+            {
+                'pid': event.pid,
+                'proctree': proctree,
+                # We're turning a little-endian insigned long ('<L')
+                # representation of the destination address sent from the
+                # kernel to a python `int` and then turning that into a string
+                # representation of an IP address:
+                'daddr': int_to_ip(event.daddr),
+                'saddr': int_to_ip(event.saddr),
+                'port': event.dport,
+                'error': error,
+            },
+        )

--- a/pidtree_bcc/probes/udp_session.j2
+++ b/pidtree_bcc/probes/udp_session.j2
@@ -13,6 +13,9 @@ struct udp_session_event {
     u64 sock_pointer;
     u32 daddr;
     u16 dport;
+{%- if container_labels %}
+    u64 mntns_id;
+{% endif -%}
 };
 
 BPF_PERF_OUTPUT(events);
@@ -62,6 +65,9 @@ int kprobe__udp_sendmsg(struct pt_regs *ctx, struct sock *sk, struct msghdr *msg
     session.sock_pointer = sock_pointer;
     bpf_probe_read(&session.daddr, sizeof(u32), &daddr);
     bpf_probe_read(&session.dport, sizeof(u16), &dport);
+    {% if container_labels -%}
+    session.mntns_id = get_mntns_id();
+    {% endif -%}
     events.perf_submit(ctx, &session, sizeof(session));
     if(trace_flag == SESSION_START) {
         // We don't care about the actual value in the map
@@ -85,6 +91,9 @@ int kprobe__inet_release(struct pt_regs *ctx, struct socket *sock) {
         session.pid = pid;
         session.type = SESSION_END;
         session.sock_pointer = sock_pointer;
+        {% if container_labels -%}
+        session.mntns_id = get_mntns_id();
+        {% endif -%}
         events.perf_submit(ctx, &session, sizeof(session));
         tracing.delete(&sock_pointer);
     }

--- a/pidtree_bcc/probes/udp_session.py
+++ b/pidtree_bcc/probes/udp_session.py
@@ -89,7 +89,7 @@ class UDPSessionProbe(BPFProbe):
                     }
                     for addr_port, begin_count in session_data['destinations'].items()
                 ]
-                return session_data
+                return self.enrich_container_name(event, session_data)
 
     @never_crash
     def _session_expiration_worker(self, session_max_duration: int):

--- a/pidtree_bcc/probes/utils.j2
+++ b/pidtree_bcc/probes/utils.j2
@@ -176,10 +176,14 @@ struct mnt_namespace {
 
 BPF_HASH({{ mntns_filter_map_name }}, u64, bool, {{ size }});
 
-static inline bool is_mntns_included() {
+static inline u64 get_mntns_id() {
     struct task_struct *task;
     task = (struct task_struct *)bpf_get_current_task();
-    u64 mntns_id = task->nsproxy->mnt_ns->ns.inum;
+    return task->nsproxy->mnt_ns->ns.inum;
+}
+
+static inline bool is_mntns_included() {
+    u64 mntns_id = get_mntns_id();
     return {{ mntns_filter_map_name }}.lookup(&mntns_id) != NULL;
 }
 {%- endmacro %}

--- a/tests/containers_test.py
+++ b/tests/containers_test.py
@@ -3,7 +3,9 @@ from unittest.mock import call
 from unittest.mock import MagicMock
 from unittest.mock import patch
 
+from pidtree_bcc.containers import ContainerEventType
 from pidtree_bcc.containers import list_container_mnt_namespaces
+from pidtree_bcc.containers import MountNSInfo
 
 
 @patch('pidtree_bcc.containers.os')
@@ -11,23 +13,26 @@ from pidtree_bcc.containers import list_container_mnt_namespaces
 def test_list_container_mnt_namespaces(mock_subprocess, mock_os):
     mock_subprocess.check_output.side_effect = [
         'aaaabbbbcccc\nddddeeeeffff\naaaacccceeee\nbbbbddddffff',
-        '123',
-        subprocess.CalledProcessError,
-        '456',
-        '789',
+        r'[{"State":{"Pid":123},"Name":"abc","Config":{"Labels":{"a":"b"}}}]',
+        subprocess.CalledProcessError(returncode=1, cmd='whatever'),
+        r'[{"State":{"Pid":456},"Name":"def","Config":{"Labels":{"a":"b"}}}]',
+        r'[{"State":{"Pid":789},"Name":"ghi","Config":{"Labels":{"a":"b"}}}]',
     ]
-    mock_os.path.exists.return_value = False
+    mock_os.path.exists.return_value = False  # force container client detection to "docker"
     mock_os.stat.side_effect = [
         MagicMock(st_ino=111),
         MagicMock(st_ino=222),
         IOError,
     ]
-    assert list_container_mnt_namespaces(['a=b']) == {111, 222}
+    assert list_container_mnt_namespaces(['a=b']) == {
+        MountNSInfo('aaaabbbbcccc', 'abc', 111, ContainerEventType.start),
+        MountNSInfo('aaaacccceeee', 'def', 222, ContainerEventType.start),
+    }
     mock_subprocess.check_output.assert_has_calls([
-        call(('docker', 'ps', '--no-trunc', '--quiet', '--filter', 'label=a=b'), encoding='utf8'),
-        call(('docker', 'inspect', '-f', r'{{.State.Pid}}', 'aaaabbbbcccc'), encoding='utf8'),
-        call(('docker', 'inspect', '-f', r'{{.State.Pid}}', 'ddddeeeeffff'), encoding='utf8'),
-        call(('docker', 'inspect', '-f', r'{{.State.Pid}}', 'aaaacccceeee'), encoding='utf8'),
+        call(('docker', 'ps', '--no-trunc', '--quiet'), encoding='utf8'),
+        call(('docker', 'inspect', 'aaaabbbbcccc'), encoding='utf8'),
+        call(('docker', 'inspect', 'ddddeeeeffff'), encoding='utf8'),
+        call(('docker', 'inspect', 'aaaacccceeee'), encoding='utf8'),
     ])
     mock_os.stat.assert_has_calls([
         call('/proc/123/ns/mnt'),


### PR DESCRIPTION
This updates the logic of the `container_labels` configuration option which was introduced in https://github.com/Yelp/pidtree-bcc/pull/95:
* switch from polling to tailing event from the containerizer daemon, attaching and detaching containers as they spawn/die.
* rather than using the same filtering logic of the `docker ps` CLI, support using glob patterns and boolean logic when defining the label filters, so it's easier to select multiple types of containers with a single instance.