### PR TITLE
better support containerd namespaces

### DIFF
--- a/pidtree_bcc/probes/__init__.py
+++ b/pidtree_bcc/probes/__init__.py
@@ -217,6 +217,7 @@ class BPFProbe:
         """ Polls running containers, filtering by label to keep mntns filtering map updated """
         last_baseline = time.time()
         self._running_containers_baseline()
+        logging.info(f'Done initial scanning for containers to attach to (found: {len(self.container_name_mapping)})')
         for mntns_info in monitor_container_mnt_namespaces(self.container_labels_filter):
             if (now := time.time()) - last_baseline > self.CONTAINER_BASELINE_INTERVAL:
                 self._running_containers_baseline()
@@ -231,6 +232,7 @@ class BPFProbe:
                     )
                     self.container_name_mapping.pop(ns_id, None)
                 continue
+            logging.info(f'Attaching to container: {mntns_info.container_name}')
             load_intset_into_map({mntns_info.ns_id}, self.bpf[self.MNTNS_FILTER_MAP_NAME])
             self.container_name_mapping[mntns_info.ns_id] = mntns_info.container_name
             self.container_idns_mapping[mntns_info.container_id] = mntns_info.ns_id


### PR DESCRIPTION
I was dealing with the odd problem of container tracing working fine when I called it, but not when run by systemd, and I figured that we had a wrapper in user envs to set the containerd namespace var properly, which of course would not be present when systemd would launch the daemon process.

Rather than address the issue in the systemd unit (which would be pretty trivial tbf), I went for a small code update the make tracing more flexible, and with a default behaviour tailored for our use cases (aka trace k8s pods).

While I was at it, I also added a couple more logging points about the container tracing background thread doing its job.